### PR TITLE
Update usage of deprecated API

### DIFF
--- a/fusion-cli/build/plugins/child-compilation-plugin.js
+++ b/fusion-cli/build/plugins/child-compilation-plugin.js
@@ -39,7 +39,8 @@ class ChildCompilationPlugin {
   }
 
   apply(compiler /*: Object*/) {
-    compiler.plugin('make', (compilation, callback) => {
+    const name = this.constructor.name;
+    compiler.hooks.make.tapAsync(name, (compilation, callback) => {
       if (this.enabledState.value === false) {
         return void callback();
       }


### PR DESCRIPTION
`compiler.plugin('make')` => `compiler.hooks.make`

This was outputting a deprecation notice on every build