### PR TITLE
Add promise instrumentation for translation keys

### DIFF
--- a/fusion-cli/build/compiler.js
+++ b/fusion-cli/build/compiler.js
@@ -153,7 +153,8 @@ function Compiler(
     clientChunkMetadata,
     legacyClientChunkMetadata,
     mergedClientChunkMetadata,
-    i18nManifest: new DeferredState(),
+    i18nManifest: new Map(),
+    i18nDeferredManifest: new DeferredState(),
     legacyBuildEnabled,
   };
   const root = path.resolve(dir);

--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -65,6 +65,7 @@ const JS_EXT_PATTERN = /\.jsx?$/;
 /*::
 import type {
   ClientChunkMetadataState,
+  TranslationsManifest,
   TranslationsManifestState,
   LegacyBuildEnabledState,
 } from "./types.js";
@@ -86,7 +87,8 @@ export type WebpackConfigOpts = {|
     clientChunkMetadata: ClientChunkMetadataState,
     legacyClientChunkMetadata: ClientChunkMetadataState,
     mergedClientChunkMetadata: ClientChunkMetadataState,
-    i18nManifest: TranslationsManifestState,
+    i18nManifest: TranslationsManifest,
+    i18nDeferredManifest: TranslationsManifestState,
     legacyBuildEnabled: LegacyBuildEnabledState,
   },
   fusionConfig: FusionRC,
@@ -451,10 +453,13 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
           state.mergedClientChunkMetadata
         ),
       runtime === 'client'
-        ? new I18nDiscoveryPlugin(state.i18nManifest)
+        ? new I18nDiscoveryPlugin(
+            state.i18nDeferredManifest,
+            state.i18nManifest
+          )
         : new LoaderContextProviderPlugin(
             translationsManifestContextKey,
-            state.i18nManifest
+            state.i18nDeferredManifest
           ),
       !dev && zopfli && zopfliWebpackPlugin,
       !dev && brotliWebpackPlugin,
@@ -465,17 +470,21 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       // in dev because the CLI will not exit with an error code if the option is enabled,
       // so failed builds would look like successful ones.
       watch && new webpack.NoEmitOnErrorsPlugin(),
-      new InstrumentedImportDependencyTemplatePlugin(
-        runtime !== 'client'
-          ? // Server
-            state.mergedClientChunkMetadata
-          : /**
-             * Client
-             * Don't wait for the client manifest on the client.
-             * The underlying plugin handles client instrumentation on its own.
-             */
-            void 0
-      ),
+      runtime === 'server'
+        ? // Server
+          new InstrumentedImportDependencyTemplatePlugin({
+            compilation: 'server',
+            clientChunkMetadata: state.mergedClientChunkMetadata,
+          })
+        : /**
+           * Client
+           * Don't wait for the client manifest on the client.
+           * The underlying plugin is able determine client chunk metadata on its own.
+           */
+          new InstrumentedImportDependencyTemplatePlugin({
+            compilation: 'client',
+            i18nManifest: state.i18nManifest,
+          }),
       dev && hmr && watch && new webpack.HotModuleReplacementPlugin(),
       !dev && runtime === 'client' && new webpack.HashedModuleIdsPlugin(),
       runtime === 'client' &&
@@ -527,7 +536,10 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
               options.optimization.splitChunks
             ),
             // need to re-apply template
-            new InstrumentedImportDependencyTemplatePlugin(void 0),
+            new InstrumentedImportDependencyTemplatePlugin({
+              compilation: 'client',
+              i18nManifest: state.i18nManifest,
+            }),
             new ClientChunkMetadataStateHydratorPlugin(
               state.legacyClientChunkMetadata
             ),

--- a/fusion-cli/build/plugins/i18n-discovery-plugin.js
+++ b/fusion-cli/build/plugins/i18n-discovery-plugin.js
@@ -16,27 +16,30 @@ import type {TranslationsManifestState, TranslationsManifest} from "../types.js"
 
 class I18nDiscoveryPlugin {
   /*::
-  manifest: TranslationsManifestState;
-  discoveryState: TranslationsManifest;
+  manifestState: TranslationsManifestState;
+  manifest: TranslationsManifest;
   */
-  constructor(manifest /*: TranslationsManifestState*/) {
+  constructor(
+    manifestState /*: TranslationsManifestState*/,
+    manifest /*: TranslationsManifest*/
+  ) {
+    this.manifestState = manifestState;
     this.manifest = manifest;
-    this.discoveryState = new Map();
   }
   apply(compiler /*: any */) {
     const name = this.constructor.name;
     // "thisCompilation" is not run in child compilations
     compiler.hooks.thisCompilation.tap(name, compilation => {
       compilation.hooks.normalModuleLoader.tap(name, (context, module) => {
-        context[translationsDiscoveryKey] = this.discoveryState;
+        context[translationsDiscoveryKey] = this.manifest;
       });
     });
     compiler.hooks.done.tap(name, () => {
-      this.manifest.resolve(this.discoveryState);
+      this.manifestState.resolve(this.manifest);
     });
     compiler.hooks.invalid.tap(name, filename => {
-      this.manifest.reset();
-      this.discoveryState.delete(filename);
+      this.manifestState.reset();
+      this.manifest.delete(filename);
     });
   }
 }

--- a/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/main.js
+++ b/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/main.js
@@ -1,0 +1,24 @@
+// @noflow
+
+import React from 'react';
+import App from 'fusion-react';
+
+function Root () {
+  const split = import('./split.js');
+  const splitWithChild = import('./split-with-child.js');
+  return (
+    <div>
+      <div data-testid="split">
+        {JSON.stringify(split.__I18N_KEYS)}
+      </div>
+      <div data-testid="split-with-child">
+        {JSON.stringify(splitWithChild.__I18N_KEYS)}
+      </div>
+    </div>
+  );
+}
+
+export default async function start() {
+  const app = new App(<Root />);
+  return app;
+}

--- a/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split-child.js
+++ b/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split-child.js
@@ -1,0 +1,10 @@
+// @noflow
+
+import React from 'react';
+import {Translate} from 'fusion-plugin-i18n-react';
+
+export default function SplitRouteChild() {
+  return (
+    <Translate id="__SPLIT_CHILD__"/>
+  );
+}

--- a/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split-with-child.js
+++ b/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split-with-child.js
@@ -1,0 +1,12 @@
+// @noflow
+
+import React, {Component} from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+import SplitRouteChild from './split-child.js';
+
+function SplitRouteWithChild () {
+  return <SplitRouteChild />;
+}
+
+export default withTranslations(['__SPLIT_WITH_CHILD__'])(SplitRouteWithChild);

--- a/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split.js
+++ b/fusion-cli/test/e2e/dynamic-import-translations/fixture/src/split.js
@@ -1,0 +1,10 @@
+// @noflow
+
+import React, {Component} from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+function SplitRoute () {
+  return <div />
+}
+
+export default withTranslations(['__SPLIT__'])(SplitRoute);

--- a/fusion-cli/test/e2e/dynamic-import-translations/fixture/translations/en-US.json
+++ b/fusion-cli/test/e2e/dynamic-import-translations/fixture/translations/en-US.json
@@ -1,0 +1,5 @@
+{
+  "__SPLIT__": "",
+  "__SPLIT_WITH_CHILD__": "",
+  "__SPLIT_CHILD__": ""
+}

--- a/fusion-cli/test/e2e/dynamic-import-translations/test.js
+++ b/fusion-cli/test/e2e/dynamic-import-translations/test.js
@@ -1,0 +1,40 @@
+// @flow
+/* eslint-env node */
+
+const t = require('assert');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const {cmd, start} = require('../utils.js');
+
+const dir = path.resolve(__dirname, './fixture');
+
+test('`fusion build` app with split translations integration', async () => {
+  var env = Object.create(process.env);
+  env.NODE_ENV = 'production';
+
+  await cmd(`build --dir=${dir} --production`, {env});
+
+  const {proc, port} = await start(`--dir=${dir}`, {env, cwd: dir});
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+  const content = await page.content();
+  t.ok(
+    content.includes('<div data-testid="split">["__SPLIT__"]</div>'),
+    'translation keys are added to promise instrumentation'
+  );
+  t.ok(
+    content.includes(
+      '<div data-testid="split-with-child">' +
+        '["__SPLIT_CHILD__","__SPLIT_WITH_CHILD__"]' +
+        '</div>'
+    ),
+    'translation keys contain keys from child imports'
+  );
+
+  browser.close();
+  proc.kill();
+}, 100000);

--- a/fusion-plugin-i18n-react/src/plugin.js
+++ b/fusion-plugin-i18n-react/src/plugin.js
@@ -24,7 +24,9 @@ class BundleSplitConsumer extends React.Component<*, *> {
     // props.provides comes from fusion-react/plugin and references i18n()
     this.i18n = props.provides.from(props.ctx);
     if (context.splitComponentLoaders) {
-      context.splitComponentLoaders.push((_, {i18nKeys}) => this.i18n.load(i18nKeys));
+      context.splitComponentLoaders.push((_, {i18nKeys}) =>
+        this.i18n.load(i18nKeys)
+      );
     }
   }
   getChildContext() {

--- a/fusion-plugin-i18n-react/src/plugin.js
+++ b/fusion-plugin-i18n-react/src/plugin.js
@@ -24,7 +24,7 @@ class BundleSplitConsumer extends React.Component<*, *> {
     // props.provides comes from fusion-react/plugin and references i18n()
     this.i18n = props.provides.from(props.ctx);
     if (context.splitComponentLoaders) {
-      context.splitComponentLoaders.push(ids => this.i18n.load(ids));
+      context.splitComponentLoaders.push((_, {i18nKeys}) => this.i18n.load(i18nKeys));
     }
   }
   getChildContext() {

--- a/fusion-plugin-i18n/src/__tests__/index.browser.js
+++ b/fusion-plugin-i18n/src/__tests__/index.browser.js
@@ -124,7 +124,7 @@ test('load', t => {
   };
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   const fetch: any = (url, options) => {
-    t.equals(url, '/_translations?ids=0', 'url is ok');
+    t.equals(url, '/_translations?keys=test-key', 'url is ok');
     t.equals(options && options.method, 'POST', 'method is ok');
     t.equals(
       options && options.headers && options.headers['X-Fusion-Locale-Code'],
@@ -138,12 +138,11 @@ test('load', t => {
   const mockContext: Context = ({}: any);
   if (plugin) {
     const i18n = plugin.from(mockContext);
-    i18n.load([0]).then(() => {
+    i18n.load(['test-key']).then(() => {
       t.ok(called, 'fetch called');
       t.equals(i18n.translate('test'), 'hello');
       t.equals(i18n.translate('interpolated', {value: 'world'}), 'hi world');
-      // $FlowFixMe
-      t.same(i18n.loadedChunks, [0]); // private
+      t.ok(i18n.translations && !('test-key' in i18n.translations));
       t.end();
     });
   } else {

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -90,7 +90,6 @@ test('ssr', async t => {
     consumeSanitizedHTML(ctx.template.body[0]).match('hello')[0],
     'hello'
   );
-  // $FlowFixMe
   t.equals(consumeSanitizedHTML(ctx.template.body[0]).match('</div>'), null);
 
   chunkTranslationMap.dispose('a.js', [0], Object.keys(data));
@@ -112,7 +111,7 @@ test('endpoint', async t => {
     preloadChunks: [],
     headers: {'accept-language': 'en_US'},
     path: '/_translations',
-    querystring: 'ids=0',
+    querystring: 'keys=test,interpolated',
     memoized: new Map(),
     body: '',
   };

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -87,7 +87,7 @@ const pluginFactory: () => PluginType = () =>
           }
           const localeCode =
             typeof i18n.locale === 'string' ? i18n.locale : i18n.locale.code;
-          const serialized = JSON.stringify({chunks, localeCode, translations});
+          const serialized = JSON.stringify({localeCode, translations});
           const script = html`
             <script type="application/json" id="__TRANSLATIONS__">
               ${serialized}
@@ -96,18 +96,11 @@ const pluginFactory: () => PluginType = () =>
           ctx.template.body.push(script);
         } else if (ctx.path === '/_translations') {
           const i18n = plugin.from(ctx);
-          const ids = querystring.parse(ctx.querystring).ids || '';
-          const chunks = ids.split(',').map(id => {
-            const parsed = parseInt(id, 10);
-            return Number.isNaN(parsed) ? id : parsed;
-          });
-          const translations = {};
-          chunks.forEach(id => {
-            const keys = [...chunkTranslationMap.translationsForChunk(id)];
-            keys.forEach(key => {
-              translations[key] = i18n.translations && i18n.translations[key];
-            });
-          });
+          const keys = querystring.parse(ctx.querystring).keys || '';
+          const translations = keys.split(',').reduce((acc, key) => {
+            acc[key] = i18n.translations && i18n.translations[key];
+            return acc;
+          }, {});
           ctx.body = translations;
           return next();
         } else {

--- a/fusion-plugin-i18n/src/types.js
+++ b/fusion-plugin-i18n/src/types.js
@@ -33,7 +33,7 @@ export type I18nServiceType = {
   ) => {
     +locale?: string | Locale,
     +translations?: TranslationsObjectType,
-    +load: (chunkIds: Array<number | string>) => Promise<void>,
+    +load: (Array<string>) => Promise<void>,
     +translate: TranslateFuncType,
   },
 };

--- a/fusion-react/src/async/__tests__/__node__/split.node.js
+++ b/fusion-react/src/async/__tests__/__node__/split.node.js
@@ -26,7 +26,7 @@ tape('Preparing an app with an async component', async t => {
 
   const ToTest = split({
     defer: false,
-    load: () => Promise.resolve({default: DeferredComponent}),
+    load: () => (Promise.resolve({default: DeferredComponent}): any),
     LoadingComponent,
     ErrorComponent,
   });
@@ -60,10 +60,7 @@ tape('Preparing an app with an errored async component', async t => {
 
   const ToTest = split({
     defer: false,
-    load: () =>
-      (Promise.reject(new Error('failed')): Promise<{
-        default: React.ComponentType<any>,
-      }>),
+    load: () => (Promise.reject(new Error('failed')): any),
     LoadingComponent,
     ErrorComponent,
   });

--- a/fusion-react/src/async/split.js
+++ b/fusion-react/src/async/split.js
@@ -10,10 +10,19 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import prepared from './prepared.js';
 
+export type InstrumentedPromise<T> = Promise<{
+  default: React.ComponentType<T>,
+}> & {
+  __MODULE_ID: string,
+  __CHUNK_IDS: Array<string>,
+  __I18N_KEYS: Array<string>,
+};
+
 declare var __webpack_modules__: {[string]: any};
 declare var __webpack_require__: any => any;
 
 const CHUNKS_KEY = '__CHUNK_IDS';
+const I18N_KEY = '__I18N_KEYS';
 
 const contextTypes = {
   splitComponentLoaders: PropTypes.array.isRequired,
@@ -31,13 +40,16 @@ export default function withAsyncComponent<Config>({
   ErrorComponent,
 }: {
   defer?: boolean,
-  load: () => Promise<{default: React.ComponentType<Config>}>,
+  load: () => InstrumentedPromise<Config>,
   LoadingComponent: React.ComponentType<any>,
   ErrorComponent: React.ComponentType<any>,
 }): React.ComponentType<Config> {
   let AsyncComponent = null;
   let error = null;
-  let chunkIds = [];
+  const metadata = {
+    chunkIds: [],
+    i18nKeys: [],
+  };
 
   function WithAsyncComponent(props) {
     if (__BROWSER__) {
@@ -64,7 +76,7 @@ export default function withAsyncComponent<Config>({
     (props, context) => {
       if (AsyncComponent) {
         if (__NODE__ && context.markAsCritical) {
-          chunkIds.forEach(chunkId => {
+          metadata.chunkIds.forEach(chunkId => {
             context.markAsCritical(chunkId);
           });
         }
@@ -75,21 +87,23 @@ export default function withAsyncComponent<Config>({
       try {
         componentPromise = load();
       } catch (e) {
-        componentPromise = Promise.reject(e);
+        componentPromise = (Promise.reject(e): any);
       }
 
-      // $FlowFixMe
-      chunkIds = componentPromise[CHUNKS_KEY] || [];
+      metadata.chunkIds = componentPromise[CHUNKS_KEY] || [];
+      metadata.i18nKeys = componentPromise[I18N_KEY] || [];
 
       if (__NODE__ && context.markAsCritical) {
-        chunkIds.forEach(chunkId => {
+        metadata.chunkIds.forEach(chunkId => {
           context.markAsCritical(chunkId);
         });
       }
 
       const loadPromises = [
         componentPromise,
-        ...context.splitComponentLoaders.map(loader => loader(chunkIds)),
+        ...context.splitComponentLoaders.map(loader =>
+          loader(metadata.chunkIds, metadata)
+        ),
       ];
 
       return Promise.all(loadPromises)


### PR DESCRIPTION
- Annotate dynamic imports with the translation keys the chunk contains
- Update fusion-react to pass keys through splitComponentLoaders to i18n plugin
- Load translations in i18n plugins from keys instead of chunk ids

Fixes issues with dynamically loading translations where routing isn't guaranteed to hit the origin the initial request was served from. This will allow looking up a translation by key instead of the id of the chunk that contains it.
