### PR TITLE
Add ability to configure transpilation and bundling with experimentalCompileTest

### DIFF
--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -205,17 +205,17 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
         if (!JS_EXT_PATTERN.test(modulePath)) {
           return false;
         }
-        const {transpile} = experimentalCompileTest(modulePath, {
-          transpile: 'spec',
-          bundle: 'client',
+        const {transform} = experimentalCompileTest(modulePath, {
+          transform: 'spec',
+          bundle: 'browser-only',
         });
-        if (transpile === 'none') {
+        if (transform === 'none') {
           return false;
-        } else if (transpile === 'all' || transpile === 'spec') {
+        } else if (transform === 'all' || transform === 'spec') {
           return true;
         } else {
           throw new Error(
-            `Unknown transpile value from experimentalCompileTest ${transpile}. Expected 'spec' | 'all' | 'none'`
+            `Unknown transform value from experimentalCompileTest ${transform}. Expected 'spec' | 'all' | 'none'`
           );
         }
       }
@@ -227,17 +227,17 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       if (!JS_EXT_PATTERN.test(modulePath)) {
         return false;
       }
-      const {transpile} = experimentalCompileTest(modulePath, {
-        transpile: fusionConfig.experimentalCompile ? 'all' : 'spec',
-        bundle: 'client',
+      const {transform} = experimentalCompileTest(modulePath, {
+        transform: fusionConfig.experimentalCompile ? 'all' : 'spec',
+        bundle: 'browser-only',
       });
-      if (transpile === 'none' || transpile === 'spec') {
+      if (transform === 'none' || transform === 'spec') {
         return false;
-      } else if (transpile === 'all') {
+      } else if (transform === 'all') {
         return true;
       } else {
         throw new Error(
-          `Unknown transpile value from experimentalCompileTest ${transpile}. Expected 'spec' | 'all' | 'none'`
+          `Unknown transform value from experimentalCompileTest ${transform}. Expected 'spec' | 'all' | 'none'`
         );
       }
     };
@@ -439,18 +439,18 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
             }
             if (experimentalCompileTest) {
               const {bundle} = experimentalCompileTest(absolutePath, {
-                transpile: 'none', // default transpile value doesn't actually matter here
-                bundle: 'client',
+                transform: 'none', // default transform value doesn't actually matter here
+                bundle: 'browser-only',
               });
-              if (bundle === 'client') {
+              if (bundle === 'browser-only') {
                 // don't bundle on the server
                 return callback(null, 'commonjs ' + absolutePath);
-              } else if (bundle === 'both') {
+              } else if (bundle === 'universal') {
                 // bundle on the server
                 return callback();
               } else {
                 throw new Error(
-                  `Unknown bundle value: ${bundle} from experimentalCompileTest. Expected 'client' | 'both'.`
+                  `Unknown bundle value: ${bundle} from experimentalCompileTest. Expected 'browser-only' | 'universal'.`
                 );
               }
             }

--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -222,6 +222,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
     : JS_EXT_PATTERN;
 
   if (experimentalCompileTest) {
+    // $FlowFixMe
     babelOverrides.test = legacyBabelOverrides.test = modulePath => {
       if (!JS_EXT_PATTERN.test(modulePath)) {
         return false;
@@ -241,6 +242,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       }
     };
   } else {
+    // $FlowFixMe
     babelOverrides.include = legacyBabelOverrides.include = [
       path.join(dir, 'src'),
       /fusion-cli(\/|\\)entries/,

--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -121,83 +121,47 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
   const runtime = COMPILATIONS[id];
   const env = dev ? 'development' : 'production';
 
-  const babelConfig = fusionConfig.experimentalCompile
-    ? getBabelConfig({
-        dev: dev,
-        fusionTransforms: true,
-        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
-        target: runtime === 'server' ? 'node-bundled' : 'browser-modern',
-        specOnly: false,
-        plugins:
-          fusionConfig.babel && fusionConfig.babel.plugins
-            ? fusionConfig.babel.plugins
-            : [],
-        presets:
-          fusionConfig.babel && fusionConfig.babel.presets
-            ? fusionConfig.babel.presets
-            : [],
-      })
-    : getBabelConfig({
-        target: runtime === 'server' ? 'node-bundled' : 'browser-modern',
-        specOnly: true,
-        plugins:
-          fusionConfig.babel && fusionConfig.babel.plugins
-            ? fusionConfig.babel.plugins
-            : [],
-        presets:
-          fusionConfig.babel && fusionConfig.babel.presets
-            ? fusionConfig.babel.presets
-            : [],
-      });
+  const babelConfig = getBabelConfig({
+    target: runtime === 'server' ? 'node-bundled' : 'browser-modern',
+    specOnly: true,
+    plugins:
+      fusionConfig.babel && fusionConfig.babel.plugins
+        ? fusionConfig.babel.plugins
+        : [],
+    presets:
+      fusionConfig.babel && fusionConfig.babel.presets
+        ? fusionConfig.babel.presets
+        : [],
+  });
 
-  const babelOverrides = fusionConfig.experimentalCompile
-    ? {}
-    : getBabelConfig({
-        dev: dev,
-        fusionTransforms: true,
-        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
-        target: runtime === 'server' ? 'node-bundled' : 'browser-modern',
-        specOnly: false,
-      });
+  const babelOverrides = getBabelConfig({
+    dev: dev,
+    fusionTransforms: true,
+    assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
+    target: runtime === 'server' ? 'node-bundled' : 'browser-modern',
+    specOnly: false,
+  });
 
-  const legacyBabelConfig = fusionConfig.experimentalCompile
-    ? getBabelConfig({
-        dev: dev,
-        fusionTransforms: true,
-        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
-        target: runtime === 'server' ? 'node-bundled' : 'browser-legacy',
-        specOnly: false,
-        plugins:
-          fusionConfig.babel && fusionConfig.babel.plugins
-            ? fusionConfig.babel.plugins
-            : [],
-        presets:
-          fusionConfig.babel && fusionConfig.babel.presets
-            ? fusionConfig.babel.presets
-            : [],
-      })
-    : getBabelConfig({
-        target: runtime === 'server' ? 'node-bundled' : 'browser-legacy',
-        specOnly: true,
-        plugins:
-          fusionConfig.babel && fusionConfig.babel.plugins
-            ? fusionConfig.babel.plugins
-            : [],
-        presets:
-          fusionConfig.babel && fusionConfig.babel.presets
-            ? fusionConfig.babel.presets
-            : [],
-      });
+  const legacyBabelConfig = getBabelConfig({
+    target: runtime === 'server' ? 'node-bundled' : 'browser-legacy',
+    specOnly: true,
+    plugins:
+      fusionConfig.babel && fusionConfig.babel.plugins
+        ? fusionConfig.babel.plugins
+        : [],
+    presets:
+      fusionConfig.babel && fusionConfig.babel.presets
+        ? fusionConfig.babel.presets
+        : [],
+  });
 
-  const legacyBabelOverrides = fusionConfig.experimentalCompile
-    ? {}
-    : getBabelConfig({
-        dev: dev,
-        fusionTransforms: true,
-        assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
-        target: runtime === 'server' ? 'node-bundled' : 'browser-legacy',
-        specOnly: false,
-      });
+  const legacyBabelOverrides = getBabelConfig({
+    dev: dev,
+    fusionTransforms: true,
+    assumeNoImportSideEffects: fusionConfig.assumeNoImportSideEffects,
+    target: runtime === 'server' ? 'node-bundled' : 'browser-legacy',
+    specOnly: false,
+  });
 
   const experimentalCompileTest = fusionConfig.experimentalCompileTest;
   const babelTester = experimentalCompileTest
@@ -228,7 +192,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
         return false;
       }
       const {transform} = experimentalCompileTest(modulePath, {
-        transform: fusionConfig.experimentalCompile ? 'all' : 'spec',
+        transform: 'spec',
         bundle: 'browser-only',
       });
       if (transform === 'none' || transform === 'spec') {

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -25,7 +25,7 @@ export type FusionRC = {
   babel?: {plugins?: Array<any>, presets?: Array<any>},
   assumeNoImportSideEffects?: boolean,
   experimentalCompile?: boolean,
-  experimentalCompileTest?: (modulePath: string) => CompileResult,
+  experimentalCompileTest?: (modulePath: string, defaults: CompileResult) => CompileResult,
   nodeBuiltins?: {[string]: any},
 };
 */

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -75,6 +75,25 @@ function isValid(config) {
     throw new Error(`Invalid property in .fusionrc.js`);
   }
 
+  if (config.experimentalCompile && config.experimentalCompileTest) {
+    throw new Error(
+      `Cannot use both experimentalCompile and experimentalCompileTest in .fusionrc.js`
+    );
+  }
+
+  if (config.experimentalCompile) {
+    console.log(
+      'WARNING: experimentalCompile is deprecated. Use experimentalCompileTest instead.'
+    );
+    config.experimentalCompileTest = (file, defaults) => {
+      return {
+        bundle: defaults.bundle,
+        transform: 'all',
+      };
+    };
+    delete config.experimentalCompile;
+  }
+
   if (
     config.babel &&
     !Object.keys(config.babel).every(el => ['plugins', 'presets'].includes(el))

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -18,7 +18,7 @@ let loggedNotice = false;
 /*::
 
 type CompileResult = {
-  bundle: 'both' | 'client',
+  bundle: 'universal' | 'browser-only',
   transpile: 'spec' | 'all' | 'none',
 };
 export type FusionRC = {

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -19,7 +19,7 @@ let loggedNotice = false;
 
 type CompileResult = {
   bundle: 'universal' | 'browser-only',
-  transpile: 'spec' | 'all' | 'none',
+  transform: 'all' | 'spec' | 'none',
 };
 export type FusionRC = {
   babel?: {plugins?: Array<any>, presets?: Array<any>},

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -16,10 +16,16 @@ const chalk = require('chalk');
 let loggedNotice = false;
 
 /*::
+
+type CompileResult = {
+  bundle: 'both' | 'client',
+  transpile: 'spec' | 'all' | 'none',
+};
 export type FusionRC = {
   babel?: {plugins?: Array<any>, presets?: Array<any>},
   assumeNoImportSideEffects?: boolean,
   experimentalCompile?: boolean,
+  experimentalCompileTest?: (modulePath: string) => CompileResult,
   nodeBuiltins?: {[string]: any},
 };
 */
@@ -61,6 +67,7 @@ function isValid(config) {
         'babel',
         'assumeNoImportSideEffects',
         'experimentalCompile',
+        'experimentalCompileTest',
         'nodeBuiltins',
       ].includes(key)
     )

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -17,15 +17,14 @@ let loggedNotice = false;
 
 /*::
 
-type CompileResult = {
-  bundle: 'universal' | 'browser-only',
-  transform: 'all' | 'spec' | 'none',
-};
+type BundleResult =  'universal' | 'browser-only';
+type TransformResult = 'all' | 'spec' | 'none';
 export type FusionRC = {
   babel?: {plugins?: Array<any>, presets?: Array<any>},
   assumeNoImportSideEffects?: boolean,
   experimentalCompile?: boolean,
-  experimentalCompileTest?: (modulePath: string, defaults: CompileResult) => CompileResult,
+  experimentalTransformTest?: (modulePath: string, defaults: TransformResult) => TransformResult,
+  experimentalBundleTest?: (modulePath: string, defaults: BundleResult) => BundleResult,
   nodeBuiltins?: {[string]: any},
 };
 */
@@ -67,7 +66,8 @@ function isValid(config) {
         'babel',
         'assumeNoImportSideEffects',
         'experimentalCompile',
-        'experimentalCompileTest',
+        'experimentalTransformTest',
+        'experimentalBundleTest',
         'nodeBuiltins',
       ].includes(key)
     )
@@ -75,21 +75,23 @@ function isValid(config) {
     throw new Error(`Invalid property in .fusionrc.js`);
   }
 
-  if (config.experimentalCompile && config.experimentalCompileTest) {
+  if (config.experimentalCompile && config.experimentalTransformTest) {
     throw new Error(
-      `Cannot use both experimentalCompile and experimentalCompileTest in .fusionrc.js`
+      `Cannot use both experimentalCompile and experimentalTransformTest in .fusionrc.js`
+    );
+  }
+  if (config.experimentalCompile && config.experimentalBundleTest) {
+    throw new Error(
+      `Cannot use both experimentalCompile and experimentalBundleTest in .fusionrc.js`
     );
   }
 
   if (config.experimentalCompile) {
     console.log(
-      'WARNING: experimentalCompile is deprecated. Use experimentalCompileTest instead.'
+      'WARNING: experimentalCompile is deprecated. Use experimentalTransformTest instead.'
     );
-    config.experimentalCompileTest = (file, defaults) => {
-      return {
-        bundle: defaults.bundle,
-        transform: 'all',
-      };
+    config.experimentalTransformTest = (file, defaults) => {
+      return 'all';
     };
     delete config.experimentalCompile;
   }

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
@@ -2,14 +2,14 @@ module.exports = {
   experimentalCompileTest(modulePath, defaults) {
     if (modulePath.includes('fixture-es2017-pkg')) {
       return {
-        bundle: 'client',
-        transpile: 'spec',
+        bundle: 'browser-only',
+        transform: 'spec',
       }
     }
     if (modulePath.includes('fixture-macro-pkg')) {
       return {
-        bundle: 'both',
-        transpile: 'all',
+        bundle: 'universal',
+        transform: 'all',
       };
     }
     return defaults;

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
@@ -1,16 +1,16 @@
 module.exports = {
-  experimentalCompileTest(modulePath, defaults) {
+  experimentalTransformTest(modulePath, defaults) {
     if (modulePath.includes('fixture-es2017-pkg')) {
-      return {
-        bundle: 'browser-only',
-        transform: 'spec',
-      }
+      return 'spec';
     }
     if (modulePath.includes('fixture-macro-pkg')) {
-      return {
-        bundle: 'universal',
-        transform: 'all',
-      };
+      return 'all';
+    }
+    return defaults;
+  },
+  experimentalBundleTest(modulePath, defaults) {
+    if (modulePath.includes('fixture-macro-pkg')) {
+      return 'universal';
     }
     return defaults;
   }

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.fusionrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  experimentalCompileTest(modulePath, defaults) {
+    if (modulePath.includes('fixture-es2017-pkg')) {
+      return {
+        bundle: 'client',
+        transpile: 'spec',
+      }
+    }
+    if (modulePath.includes('fixture-macro-pkg')) {
+      return {
+        bundle: 'both',
+        transpile: 'all',
+      };
+    }
+    return defaults;
+  }
+}

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.gitignore
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/.gitignore
@@ -1,0 +1,3 @@
+!node_modules/
+!node_modules/fixture-es2017-pkg
+!node_modules/fixture-macro-pkg

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-es2017-pkg/index.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-es2017-pkg/index.js
@@ -1,0 +1,2 @@
+// @flow
+module.exports = async () => 'fixturepkg_string';

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-es2017-pkg/package.json
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-es2017-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-es2017-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-macro-pkg/index.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-macro-pkg/index.js
@@ -1,0 +1,6 @@
+// @flow
+import {assetUrl} from 'fusion-core';
+
+export default async () => {
+  return assetUrl('./package.json');
+};

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-macro-pkg/package.json
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/node_modules/fixture-macro-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-macro-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/src/main.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/src/main.js
@@ -1,0 +1,12 @@
+// @noflow
+import App from 'fusion-core';
+
+import fixture from 'fixture-es2017-pkg';
+import other from 'fixture-macro-pkg';
+
+export default async function() {
+  const app = new App('element', el => el);
+  fixture();
+  other();
+  return app;
+}

--- a/fusion-cli/test/e2e/transpile-node-modules-extended/test.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/test.js
@@ -1,0 +1,70 @@
+// @flow
+/* eslint-env node */
+
+const path = require('path');
+const fs = require('fs');
+const babel = require('@babel/core');
+const {promisify} = require('util');
+const t = require('assert');
+
+const exists = promisify(fs.exists);
+const readFile = promisify(fs.readFile);
+
+const {cmd} = require('../utils.js');
+
+const dir = path.resolve(__dirname, './fixture');
+
+test('transpiles node_modules', async () => {
+  await cmd(`build --dir=${dir}`);
+
+  const clientVendorPath = path.resolve(
+    dir,
+    `.fusion/dist/development/client/client-legacy-vendor.js`
+  );
+
+  const serverMainPath = path.resolve(
+    dir,
+    `.fusion/dist/development/server/server-main.js`
+  );
+
+  t.ok(await exists(clientVendorPath), 'Client vendor file gets compiled');
+  t.ok(await exists(serverMainPath), 'Server main file gets compiled');
+
+  const clientVendor = await readFile(clientVendorPath, 'utf8');
+  const serverMain = await readFile(serverMainPath, 'utf8');
+
+  babel.transform(clientVendor, {
+    plugins: [
+      () => {
+        return {
+          visitor: {
+            FunctionDeclaration: path => {
+              if (path.node.async) {
+                // $FlowFixMe
+                t.fail(`bundle has untranspiled async function`);
+              }
+            },
+            ArrowFunctionExpression: path => {
+              if (path.node.async) {
+                // $FlowFixMe
+                t.fail('bundle has untranspiled async function');
+              }
+            },
+            FunctionExpression: path => {
+              if (path.node.async) {
+                // $FlowFixMe
+                t.fail('bundle has untranspiled async function');
+              }
+            },
+          },
+        };
+      },
+    ],
+  });
+
+  t.ok(clientVendor.includes(`"fixturepkg_string"`));
+  t.equal(serverMain.includes(`"fixturepkg_string"`), false);
+  t.ok(
+    serverMain.includes(`__SECRET_FILE_LOADER__?assetUrl=true!./package.json`)
+  );
+}, 100000);


### PR DESCRIPTION
This adds the `experimentalCompileTest` option to .fusionrc.js. It remains 
undocumented as of now. We will first test in a prerelease to make sure
it fits our needs. Once we are ready to release it outside of experimental
mode, we will add documentation.