### PR TITLE
Handle non-Error promise rejections

### DIFF
--- a/fusion-plugin-error-handling/fixtures/unhandled-rejection-non-error.js
+++ b/fusion-plugin-error-handling/fixtures/unhandled-rejection-non-error.js
@@ -1,0 +1,29 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+const App = require('fusion-core').default;
+// eslint-disable-next-line import/no-unresolved
+// $FlowFixMe
+const {default: Plugin, ErrorHandlerToken} = require('../dist/index.js');
+
+const onError = e => {
+  console.log('ERROR HANDLER', e); // eslint-disable-line
+  console.log('INSTANCEOF ERROR', e instanceof Error); // eslint-disable-line
+};
+
+const app = new App('el', el => el);
+
+app.register(Plugin);
+app.register(ErrorHandlerToken, onError);
+app.resolve();
+
+// keep the process running
+setInterval(() => {}, 1000);
+
+Promise.reject('foobar');

--- a/fusion-plugin-error-handling/src/__tests__/index.node.js
+++ b/fusion-plugin-error-handling/src/__tests__/index.node.js
@@ -115,3 +115,20 @@ test('Unhandled rejections', async t => {
     t.end();
   });
 });
+
+test('Unhandled rejections with non-error', async t => {
+  // $FlowFixMe
+  const forked = fork('./fixtures/unhandled-rejection-non-error.js', {
+    stdio: 'pipe',
+  });
+  let stdout = '';
+  forked.stdout.on('data', data => {
+    stdout += data.toString();
+  });
+  forked.on('close', code => {
+    t.equal(code, 1, 'exits with code 1');
+    t.ok(stdout.includes('ERROR HANDLER'), 'outputs expected error');
+    t.ok(stdout.includes('INSTANCEOF ERROR true'), 'outputs expected error');
+    t.end();
+  });
+});

--- a/fusion-plugin-error-handling/src/server.js
+++ b/fusion-plugin-error-handling/src/server.js
@@ -32,8 +32,13 @@ const plugin =
     deps: {onError: ErrorHandlerToken},
     provides({onError}) {
       assert(typeof onError === 'function', '{onError} must be a function');
-      const err = async e => {
-        await onError(e, captureTypes.server);
+      // It's possible to call reject with a non-error
+      const err = async (e: mixed) => {
+        if (e instanceof Error) {
+          await onError(e, captureTypes.server);
+        } else {
+          await onError(new Error(String(e)), captureTypes.server);
+        }
         process.exit(1);
       };
       process.once('uncaughtException', err);


### PR DESCRIPTION
It's possible to reject a non-Error value, so we should handle this and coerce it to an Error when that happens.