### PR TITLE
Resolve Flow complaints in fusion-plugin-apollo

### DIFF
--- a/fusion-plugin-apollo/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-apollo/flow-typed/npm/redux_v4.x.x.js
@@ -1,8 +1,7 @@
-// flow-typed signature: df80bdd535bfed9cf3223e077f3b4543
-// flow-typed version: c4c8963c9c/redux_v4.x.x/flow_>=v0.55.x
+// flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
+// flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
 
 declare module 'redux' {
-
   /*
 
     S = State
@@ -11,49 +10,91 @@ declare module 'redux' {
 
   */
 
+  declare export type Action<T> = {
+    type: T
+  }
+
   declare export type DispatchAPI<A> = (action: A) => A;
-  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
-    dispatch: D;
-    getState(): S;
+    dispatch: D,
+    getState(): S,
   };
 
   declare export type Store<S, A, D = Dispatch<A>> = {
     // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
-    dispatch: D;
-    getState(): S;
-    subscribe(listener: () => void): () => void;
-    replaceReducer(nextReducer: Reducer<S, A>): void
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
   };
 
   declare export type Reducer<S, A> = (state: S | void, action: A) => S;
 
-  declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
 
-  declare export type Middleware<S, A, D = Dispatch<A>> =
-    (api: MiddlewareAPI<S, A, D>) =>
-      (next: D) => D;
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
 
   declare export type StoreCreator<S, A, D = Dispatch<A>> = {
-    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
   };
 
-  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
 
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
 
-  declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
 
   declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
-  declare export type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
 
-  declare export function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
-  declare export function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
 
-  declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 
   declare export var compose: $Compose;
 }


### PR DESCRIPTION
Resolves [WPT-3239](https://jeng.uberinternal.com/browse/WPT-3239):

Updates Flow libdef for `redux` to resolve the following error:

```sh
$ flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/redux_v4.x.x.js:15:43

Deprecated utility. Using $Subtype types is not recommended! (deprecated-utility)

     12│   */
     13│
     14│   declare export type DispatchAPI<A> = (action: A) => A;
     15│   declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
     16│
     17│   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     18│     dispatch: D;



Found 1 error
error Command failed with exit code 2.
```