### PR TITLE
Add throwing an error when ServiceContext.Provider wasn't registered

### DIFF
--- a/fusion-react/src/context.js
+++ b/fusion-react/src/context.js
@@ -11,7 +11,11 @@ import type FusionApp, {FusionPlugin, Middleware} from 'fusion-core';
 import type {Element} from 'react';
 
 export const FusionContext = React.createContext<any>({});
-export const ServiceContext = React.createContext<any>(() => {});
+export const ServiceContext = React.createContext<any>(() => {
+  throw new Error(
+    '`ServiceContext.Provider` was never added to the component tree. This usually happens in tests that are using `ServiceContext` but never called `app.register(serviceContexPlugin(app))`'
+  );
+});
 
 type ReturnsType<T> = () => T;
 

--- a/fusion-react/src/context.js
+++ b/fusion-react/src/context.js
@@ -13,7 +13,7 @@ import type {Element} from 'react';
 export const FusionContext = React.createContext<any>({});
 export const ServiceContext = React.createContext<any>(() => {
   throw new Error(
-    '`ServiceContext.Provider` was not found. This occurs if you are attempting to use `ServiceContext` in a non-React fusion application.'
+    '`ServiceContext.Provider` was not found. This occurs if you are attempting to use `ServiceContext` in a non-React Fusion.js application.'
   );
 });
 

--- a/fusion-react/src/context.js
+++ b/fusion-react/src/context.js
@@ -13,7 +13,7 @@ import type {Element} from 'react';
 export const FusionContext = React.createContext<any>({});
 export const ServiceContext = React.createContext<any>(() => {
   throw new Error(
-    '`ServiceContext.Provider` was never added to the component tree. This usually happens in tests that are using `ServiceContext` but never called `app.register(serviceContexPlugin(app))`'
+    '`ServiceContext.Provider` was not found. This occurs if you are attempting to use `ServiceContext` in a non-React fusion application.'
   );
 });
 

--- a/fusion-react/src/index.js
+++ b/fusion-react/src/index.js
@@ -100,6 +100,7 @@ export {
   Provider,
   ServiceConsumer,
   ServiceContext,
+  serviceContextPlugin,
   useService,
   withServices,
 };

--- a/fusion-react/src/index.js
+++ b/fusion-react/src/index.js
@@ -100,7 +100,6 @@ export {
   Provider,
   ServiceConsumer,
   ServiceContext,
-  serviceContextPlugin,
   useService,
   withServices,
 };


### PR DESCRIPTION
This should never happen in fusion-react apps, but will happen in minimal test setups that try to use `useService` or the like.