### PR TITLE
Update create-fusion-app scaffold

### DIFF
--- a/create-fusion-app/bin/cli.js
+++ b/create-fusion-app/bin/cli.js
@@ -32,6 +32,7 @@ scaffold({
   cwd: path.join(__dirname, '..'),
   projectPath: path.join(process.cwd(), projectName),
   project: projectName,
+  packageJsonFields: {name: projectName},
 })
   .then(() => {
     console.log(`

--- a/create-fusion-app/templates/basic/content/package.json
+++ b/create-fusion-app/templates/basic/content/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-fusion-app",
   "version": "0.0.0",
-  "main": "index.js",
+  "private": true,
   "dependencies": {
     "fusion-cli": "^1.18.3",
     "fusion-core": "^1.10.6",

--- a/create-fusion-app/tests/test.js
+++ b/create-fusion-app/tests/test.js
@@ -4,6 +4,7 @@
 const {promisify} = require('util');
 const exec = promisify(require('child_process').exec);
 const {startServer} = require('../test-utils/test-utils.js');
+const path = require('path');
 const puppeteer = require('puppeteer');
 
 function log(execOutput) {
@@ -11,13 +12,15 @@ function log(execOutput) {
   console.log(execOutput.stdout);
 }
 
+const appName = 'test-scaffold';
+
 test('scaffolded app tests pass', async () => {
   await exec(`mkdir test-artifacts`);
   log(
     await exec(`node ../bin/cli.js test-scaffold`, {cwd: './test-artifacts'})
   );
 
-  const options = {cwd: './test-artifacts/test-scaffold'};
+  const options = {cwd: `./test-artifacts/${appName}`};
   log(await exec(`yarn build`, options));
 
   // Spin up server and validate SSR response
@@ -31,6 +34,14 @@ test('scaffolded app tests pass', async () => {
   const response = await page.content();
   await browser.close();
   expect(response).toContain('Fusion.js');
+
+  const newPackageJson = require(
+    path.join(
+      __dirname,
+      `../test-artifacts/${appName}/package.json`
+    )
+  );
+  expect(newPackageJson.name).toEqual(appName);
 
   proc.kill();
 }, 300000);

--- a/create-fusion-app/tests/test.js
+++ b/create-fusion-app/tests/test.js
@@ -5,6 +5,7 @@ const {promisify} = require('util');
 const exec = promisify(require('child_process').exec);
 const {startServer} = require('../test-utils/test-utils.js');
 const path = require('path');
+const fs = require('fs');
 const puppeteer = require('puppeteer');
 
 function log(execOutput) {
@@ -35,11 +36,9 @@ test('scaffolded app tests pass', async () => {
   await browser.close();
   expect(response).toContain('Fusion.js');
 
-  const newPackageJson = require(
-    path.join(
-      __dirname,
-      `../test-artifacts/${appName}/package.json`
-    )
+  const newPackageJson = fs.readFileSync(
+    path.join(__dirname, `../test-artifacts/${appName}/package.json`),
+    'utf-8'
   );
   expect(newPackageJson.name).toEqual(appName);
 

--- a/create-fusion-app/tests/test.js
+++ b/create-fusion-app/tests/test.js
@@ -36,9 +36,11 @@ test('scaffolded app tests pass', async () => {
   await browser.close();
   expect(response).toContain('Fusion.js');
 
-  const newPackageJson = fs.readFileSync(
-    path.join(__dirname, `../test-artifacts/${appName}/package.json`),
-    'utf-8'
+  const newPackageJson /*: {[string]:any}*/ = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, `../test-artifacts/${appName}/package.json`),
+      'utf-8'
+    )
   );
   expect(newPackageJson.name).toEqual(appName);
 


### PR DESCRIPTION
Update app scaffold `package.json`
- change name to app name when scaffolding
- add `private: true`
- remove `main` field, since apps has no entrypoint