### PR TITLE
Emit RPC stats from the browser

### DIFF
--- a/fusion-plugin-rpc/src/__tests__/create-mock-emitter.js
+++ b/fusion-plugin-rpc/src/__tests__/create-mock-emitter.js
@@ -1,0 +1,23 @@
+// @flow
+import type {IEmitter} from '../types.js';
+
+function createMockEmitter<TProps>(props: TProps): IEmitter {
+  const emitter = {
+    from: () => {
+      return emitter;
+    },
+    emit: () => {},
+    setFrequency: () => {},
+    teardown: () => {},
+    map: () => {},
+    on: () => {},
+    off: () => {},
+    mapEvent: () => {},
+    handleEvent: () => {},
+    flush: () => undefined,
+    ...props,
+  };
+  return emitter;
+}
+
+export default createMockEmitter;

--- a/fusion-plugin-rpc/src/__tests__/index.node.js
+++ b/fusion-plugin-rpc/src/__tests__/index.node.js
@@ -20,6 +20,7 @@ import RPCPlugin from '../server';
 import type {IEmitter, RPCServiceType} from '../types.js';
 import MockRPCPlugin from '../mock.js';
 import ResponseError from '../response-error.js';
+import createMockEmitter from './create-mock-emitter';
 
 const MockPluginToken: Token<RPCServiceType> = createToken('test-plugin-token');
 const MOCK_JSON_PARAMS = {test: 'test-args'};
@@ -45,25 +46,6 @@ function createTestFixture() {
   app.register(RPCHandlersToken, mockHandlers);
   app.register(MockPluginToken, RPCPlugin);
   return app;
-}
-
-function createMockEmitter<TProps>(props: TProps): IEmitter {
-  const emitter = {
-    from: () => {
-      return emitter;
-    },
-    emit: () => {},
-    setFrequency: () => {},
-    teardown: () => {},
-    map: () => {},
-    on: () => {},
-    off: () => {},
-    mapEvent: () => {},
-    handleEvent: () => {},
-    flush: () => undefined,
-    ...props,
-  };
-  return emitter;
 }
 
 function mockRequest() {

--- a/fusion-plugin-rpc/src/__tests__/index.node.js
+++ b/fusion-plugin-rpc/src/__tests__/index.node.js
@@ -27,6 +27,13 @@ const MOCK_JSON_PARAMS = {test: 'test-args'};
 
 const mockService: RPCServiceType = getService(() => {
   const app = new App('content', el => el);
+  const mockEmitter: IEmitter = (new MockEmitter(): any);
+  // $FlowFixMe
+  mockEmitter.from = () => mockEmitter;
+  const mockEmitterPlugin = createPlugin({
+    provides: () => mockEmitter,
+  });
+  app.register(UniversalEventsToken, mockEmitterPlugin);
   app.register(RPCHandlersToken, {});
   return app;
 }, MockRPCPlugin);

--- a/fusion-plugin-rpc/src/__tests__/test-mock.js
+++ b/fusion-plugin-rpc/src/__tests__/test-mock.js
@@ -7,6 +7,7 @@
  */
 
 import test from 'tape-cup';
+import MockEmitter from 'events';
 
 import App, {
   createPlugin,
@@ -15,17 +16,25 @@ import App, {
   type Context,
 } from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 import {RPCHandlersToken} from '../tokens';
 import RPCPlugin from '../mock';
-import type {RPCServiceType} from '../types.js';
+import type {RPCServiceType, IEmitter} from '../types.js';
 
 const MockPluginToken: Token<RPCServiceType> = createToken('test-plugin-token');
 const mockCtx = (({}: any): Context);
 function createTestFixture() {
   const mockHandlers = {};
+  const mockEmitter: IEmitter = (new MockEmitter(): any);
+  // $FlowFixMe
+  mockEmitter.from = () => mockEmitter;
+  const mockEmitterPlugin = createPlugin({
+    provides: () => mockEmitter,
+  });
 
   const app = new App('content', el => el);
+  app.register(UniversalEventsToken, mockEmitterPlugin);
   app.register(RPCHandlersToken, mockHandlers);
   app.register(MockPluginToken, RPCPlugin);
   return app;

--- a/fusion-plugin-rpc/src/browser.js
+++ b/fusion-plugin-rpc/src/browser.js
@@ -24,7 +24,7 @@ class RPC {
   handlers: ?HandlerType;
   fetch: ?Fetch;
 
-  constructor(fetch: Fetch, emitter: any) {
+  constructor(fetch: Fetch, emitter: IEmitter) {
     this.fetch = fetch;
     this.emitter = emitter;
   }

--- a/fusion-plugin-rpc/src/mock.js
+++ b/fusion-plugin-rpc/src/mock.js
@@ -9,6 +9,7 @@
 import {createPlugin} from 'fusion-core';
 import type {Context} from 'fusion-core';
 import type {Fetch} from 'fusion-tokens';
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 import MissingHandlerError from './missing-handler-error';
 import {RPCHandlersToken} from './tokens';
@@ -40,6 +41,7 @@ class RPC {
 const plugin: RPCPluginType = createPlugin({
   deps: {
     handlers: RPCHandlersToken,
+    emitter: UniversalEventsToken,
   },
   provides: ({handlers} = {}) => {
     return {from: () => new RPC(handlers)};

--- a/fusion-plugin-rpc/src/server.js
+++ b/fusion-plugin-rpc/src/server.js
@@ -34,7 +34,7 @@ class RPC {
   handlers: ?HandlerType;
   fetch: ?Fetch;
 
-  constructor(emitter: any, handlers: any, ctx: Context): RPC {
+  constructor(emitter: IEmitter, handlers: any, ctx: Context): RPC {
     if (!ctx || !ctx.headers) {
       throw new Error('fusion-plugin-rpc requires `ctx`');
     }

--- a/fusion-plugin-rpc/src/types.js
+++ b/fusion-plugin-rpc/src/types.js
@@ -19,7 +19,7 @@ import {
 type ExtractReturnType = <V>(() => V) => V;
 
 export type RPCDepsType = {
-  emitter?: typeof UniversalEventsToken,
+  emitter: typeof UniversalEventsToken,
   handlers?: typeof RPCHandlersToken,
   bodyParserOptions?: typeof BodyParserOptionsToken.optional,
   fetch?: typeof FetchToken,


### PR DESCRIPTION
Mirrored from https://github.com/fusionjs/fusion-plugin-rpc/pull/222:

> Currently stats are emitted on the server for each RPC call but my project now has the use case of understanding how long an RPC call lasts on the client (we want to measure the over the wire time).