### PR TITLE
Add hook for getting Redux store

### DIFF
--- a/fusion-plugin-react-redux/package.json
+++ b/fusion-plugin-react-redux/package.json
@@ -42,6 +42,7 @@
     "execa": "^1.0.0",
     "flow-bin": "^0.98.1",
     "fusion-core": "0.0.0-monorepo",
+    "fusion-react": "0.0.0-monorepo",
     "fusion-test-utils": "0.0.0-monorepo",
     "nyc": "^14.1.0",
     "prettier": "^1.17.0",
@@ -54,6 +55,7 @@
   },
   "peerDependencies": {
     "fusion-core": "0.0.0-monorepo",
+    "fusion-react": "0.0.0-monorepo",
     "react": "^16.8.6",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1"

--- a/fusion-plugin-react-redux/src/__tests__/index.node.js
+++ b/fusion-plugin-react-redux/src/__tests__/index.node.js
@@ -15,7 +15,7 @@ import ReactApp from 'fusion-react';
 import type {FusionPlugin} from 'fusion-core';
 import {getSimulator, getService} from 'fusion-test-utils';
 
-import {useRedux} from '../hook.js'
+import {useRedux} from '../hook.js';
 import Redux from '../index.js';
 import {
   EnhancerToken,
@@ -51,20 +51,20 @@ tape('useRedux has access to Redux', async t => {
       test: action.payload || 1,
     };
   };
-  const Root = function () {
+  const Root = function() {
+    const store = useRedux();
     if (!didRender) {
       didRender = true;
-      const store = useRedux();
       t.deepLooseEqual(store.getState(), {test: 1});
       store.dispatch({type: 'CHANGE', payload: 2});
       t.equals(store.getState().test, 2, 'state receives dispatch');
     }
     return 'hello';
-  }
+  };
   const app = new ReactApp(React.createElement(Root));
   app.register(ReducerToken, reducer);
   app.register(ReduxToken, Redux);
-  const sim = getSimulator(app)
+  const sim = getSimulator(app);
   await sim.render('/');
   t.ok(didRender);
   t.end();

--- a/fusion-plugin-react-redux/src/hook.js
+++ b/fusion-plugin-react-redux/src/hook.js
@@ -15,4 +15,3 @@ export function useRedux() {
   const {store} = useService(ReduxToken).from(ctx);
   return store;
 }
-

--- a/fusion-plugin-react-redux/src/hook.js
+++ b/fusion-plugin-react-redux/src/hook.js
@@ -1,0 +1,18 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React from 'react';
+import {FusionContext, useService} from 'fusion-react';
+import {ReduxToken} from './tokens';
+
+export function useRedux() {
+  const ctx = React.useContext(FusionContext);
+  const {store} = useService(ReduxToken).from(ctx);
+  return store;
+}
+

--- a/fusion-plugin-react-redux/src/index.js
+++ b/fusion-plugin-react-redux/src/index.js
@@ -13,6 +13,8 @@ export default (__NODE__ ? serverPlugin : browserPlugin());
 
 export type {GetInitialStateType} from './types';
 
+export {useRedux} from './hook';
+
 export {
   ReduxToken,
   ReducerToken,


### PR DESCRIPTION
Add custom hook in `fusion-plugin-react-redux` for a simpler interface

The argument is that this is too much boilerplate for a super common task.
```js
import {FusionContext, useService} from 'fusion-react';
import {ReduxToken} from 'fusion-plugin-react-redux';
// ...
const ctx = React.useContext(FusionContext);
const reduxService = useService(ReduxToken);
const redux = reduxService.from(ctx);
const store = redux.store;
```

becomes

```js
import {useRedux} from 'fusion-plugin-react-redux';
// ...
const store = useRedux();
```