### PR TITLE
Update libdef files to resolve remaining Flow complaints

### DIFF
--- a/fusion-plugin-react-router/flow-typed/npm/history_v4.9.x.js
+++ b/fusion-plugin-react-router/flow-typed/npm/history_v4.9.x.js
@@ -1,24 +1,5 @@
 // @flow
-// flow-typed signature: 540e42745f797051f3bf17a6af1ccf06
-// flow-typed version: 6a3fe49a8b/history_v4.x.x/flow_>=v0.25.x
-
 declare module 'history' {
-  declare type LocationType = {
-    pathname: string,
-    search: string,
-    hash: string,
-    state?: Object,
-    key?: string,
-  };
-
-  declare function parsePath(path: string | LocationType): LocationType;
-
-  declare function createPath(
-    path: string | LocationType
-  ): string | LocationType;
-}
-
-declare module 'history/createBrowserHistory' {
   declare function Unblock(): void;
 
   declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
@@ -28,8 +9,8 @@ declare module 'history/createBrowserHistory' {
     search: string,
     hash: string,
     // Browser and Memory specific
-    state?: {},
-    key?: string,
+    state: {},
+    key: string,
   };
 
   declare interface IBrowserHistory {
@@ -39,19 +20,20 @@ declare module 'history/createBrowserHistory' {
     push(path: string, state?: {}): void;
     push(location: $Shape<BrowserLocation>): void;
     replace(path: string, state?: {}): void;
-    replace(path: $Shape<BrowserLocation>, state?: {}): void;
+    replace(location: $Shape<BrowserLocation>): void;
     go(n: number): void;
     goBack(): void;
     goForward(): void;
-    listen: any;
+    listen((location: BrowserLocation, action: Action) => void): void;
+    block(message: string): typeof Unblock;
     block(
-      callback: (location: BrowserLocation, action: Action) => boolean
-    ): void;
+      (location: BrowserLocation, action: Action) => string
+    ): typeof Unblock;
   }
 
   declare export type BrowserHistory = IBrowserHistory;
 
-  declare type HistoryOpts = {
+  declare type BrowserHistoryOpts = {
     basename?: string,
     forceRefresh?: boolean,
     getUserConfirmation?: (
@@ -60,13 +42,9 @@ declare module 'history/createBrowserHistory' {
     ) => void,
   };
 
-  declare export default (opts?: HistoryOpts) => BrowserHistory;
-}
-
-declare module 'history/createMemoryHistory' {
-  declare function Unblock(): void;
-
-  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
+  declare function createBrowserHistory(
+    opts?: BrowserHistoryOpts
+  ): BrowserHistory;
 
   declare export type MemoryLocation = {
     pathname: string,
@@ -92,14 +70,14 @@ declare module 'history/createMemoryHistory' {
     goForward(): void;
     // Memory only
     canGo(n: number): boolean;
-    listen: Function;
+    listen((location: MemoryLocation, action: Action) => void): void;
     block(message: string): typeof Unblock;
     block((location: MemoryLocation, action: Action) => string): typeof Unblock;
   }
 
   declare export type MemoryHistory = IMemoryHistory;
 
-  declare type HistoryOpts = {
+  declare type MemoryHistoryOpts = {
     initialEntries?: Array<string>,
     initialIndex?: number,
     keyLength?: number,
@@ -109,13 +87,7 @@ declare module 'history/createMemoryHistory' {
     ) => void,
   };
 
-  declare export default (opts?: HistoryOpts) => MemoryHistory;
-}
-
-declare module 'history/createHashHistory' {
-  declare function Unblock(): void;
-
-  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
+  declare function createMemoryHistory(opts?: MemoryHistoryOpts): MemoryHistory;
 
   declare export type HashLocation = {
     pathname: string,
@@ -134,7 +106,7 @@ declare module 'history/createHashHistory' {
     go(n: number): void;
     goBack(): void;
     goForward(): void;
-    listen: Function;
+    listen((location: HashLocation, action: Action) => void): void;
     block(message: string): typeof Unblock;
     block((location: HashLocation, action: Action) => string): typeof Unblock;
     push(path: string): void;
@@ -142,7 +114,7 @@ declare module 'history/createHashHistory' {
 
   declare export type HashHistory = IHashHistory;
 
-  declare type HistoryOpts = {
+  declare type HashHistoryOpts = {
     basename?: string,
     hashType: 'slash' | 'noslash' | 'hashbang',
     getUserConfirmation?: (
@@ -151,5 +123,19 @@ declare module 'history/createHashHistory' {
     ) => void,
   };
 
-  declare export default (opts?: HistoryOpts) => HashHistory;
+  declare function createHashHistory(opts?: HashHistoryOpts): HashHistory;
+
+  declare type LocationType = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: Object,
+    key?: string,
+  };
+
+  declare function parsePath(path: string | LocationType): LocationType;
+
+  declare function createPath(
+    path: string | LocationType
+  ): string | LocationType;
 }

--- a/fusion-plugin-react-router/flow-typed/npm/prop-types_v15.x.x.js
+++ b/fusion-plugin-react-router/flow-typed/npm/prop-types_v15.x.x.js
@@ -1,6 +1,6 @@
 // @flow
-// flow-typed signature: bfbfd99e158d6ba552a6d4d43e9ea945
-// flow-typed version: 84e615b60b/prop-types_v15.x.x/flow_>=v0.89.x
+
+/* eslint-disable */
 
 type $npm$propTypes$ReactPropsCheckType = (
   props: any,

--- a/fusion-plugin-react-router/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/fusion-plugin-react-router/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,6 +1,4 @@
 // @flow
-// flow-typed signature: 5514042185f40bea708c7d73e53fabda
-// flow-typed version: be05cd918c/react-router-dom_v4.x.x/flow_>=v0.63.x
 
 declare module 'react-router-dom' {
   declare export var BrowserRouter: React$ComponentType<{|
@@ -123,10 +121,10 @@ declare module 'react-router-dom' {
     children?: React$Node,
   |}>;
 
-  declare export var Router: React$ComponentType<{|
+  declare export var Router: React$ComponentType<{
     history: RouterHistory,
     children?: React$Node,
-  |}>;
+  }>;
 
   declare export var Prompt: React$ComponentType<{|
     message: string | ((location: Location) => string | boolean),

--- a/fusion-plugin-react-router/src/types.js
+++ b/fusion-plugin-react-router/src/types.js
@@ -12,7 +12,7 @@ export type LocationType = {
   pathname: string,
   search: string,
   hash: string,
-  state?: Object,
+  state?: any,
   key?: string,
 };
 
@@ -20,7 +20,7 @@ export type LocationShapeType = {
   pathname?: string,
   search?: string,
   hash?: string,
-  state?: Object,
+  state?: any,
 };
 
 /* Types below adapted from flow-typed's libdef for react-router-dom
@@ -49,13 +49,13 @@ export type LinkType = React.ComponentType<{
 }>;
 
 export type NavLinkType = React.ComponentType<{
-  to?: string | LocationShapeType,
+  to: string | LocationShapeType,
   activeClassName?: string,
   className?: string,
   activeStyle?: Object,
   style?: Object,
   isActive?: (match: MatchType, location: LocationType) => boolean,
-  children?: React.Node,
+  children?: React$Node,
   exact?: boolean,
   strict?: boolean,
 }>;
@@ -77,8 +77,9 @@ export type RouterHistoryType = {
   goForward(): void,
   canGo?: (n: number) => boolean,
   block(
-    callback: (location: LocationType, action: HistoryActionType) => boolean
-  ): void,
+      callback: | string // eslint-disable-line
+      | ((location: LocationType, action: HistoryActionType) => ?string)
+  ): () => void,
   // createMemoryHistory
   index?: number,
   entries?: Array<LocationType>,
@@ -166,10 +167,10 @@ export type SwitchType = React.ComponentType<{|
   location?: LocationType,
 |}>;
 
-export type withRouterType = <WrappedComponent: React.ComponentType<*>>(
-  Component: WrappedComponent
-) => React.ComponentType<
-  $Diff<React.ElementConfig<WrappedComponent>, ContextRouterVoid>
+export type withRouterType = <Props: {}, Component: React.ComponentType<Props>>(
+  WrappedComponent: Component
+) => React$ComponentType<
+  $Diff<React.ElementConfig<Component>, ContextRouterVoid>
 >;
 
 type MatchPathOptions = {

--- a/fusion-plugin-react-router/src/types.js
+++ b/fusion-plugin-react-router/src/types.js
@@ -55,7 +55,7 @@ export type NavLinkType = React.ComponentType<{
   activeStyle?: Object,
   style?: Object,
   isActive?: (match: MatchType, location: LocationType) => boolean,
-  children?: React$Node,
+  children?: React.Node,
   exact?: boolean,
   strict?: boolean,
 }>;
@@ -169,7 +169,7 @@ export type SwitchType = React.ComponentType<{|
 
 export type withRouterType = <Props: {}, Component: React.ComponentType<Props>>(
   WrappedComponent: Component
-) => React$ComponentType<
+) => React.ComponentType<
   $Diff<React.ElementConfig<Component>, ContextRouterVoid>
 >;
 


### PR DESCRIPTION
We aren't seeing this in the individual package as the root `flow-typed` is missing some libdef files (and therefore goes untyped).  If you run `yarn flow` within this package, we see the following failures:

```sh
$ flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/browser.js:49:30

Cannot assign NavLinkUntyped to NavLink because in property to:
 • Either undefined [1] is incompatible with string [2].
 • Or undefined [1] is incompatible with LocationShape [3].

        src/browser.js
        46│ const HashRouter: HashRouterType = HashRouterUntyped;
        47│ const Link: LinkType = LinkUntyped;
        48│ const MemoryRouter: MemoryRouterType = MemoryRouterUntyped;
        49│ const NavLink: NavLinkType = NavLinkUntyped;
        50│ const Prompt: PromptType = PromptUntyped;
        51│ const StaticRouter: StaticRouterType = StaticRouterUntyped;
        52│ const Switch: SwitchType = SwitchUntyped;

        flow-typed/npm/react-router-dom_v4.x.x.js
 [2][3] 29│     to: string | LocationShape,

        src/types.js
    [1] 52│   to?: string | LocationShapeType,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/browser.js:54:19

Cannot use withRouterType [1] with fewer than 2 type arguments.

     51│ const StaticRouter: StaticRouterType = StaticRouterUntyped;
     52│ const Switch: SwitchType = SwitchUntyped;
     53│ const matchPath: matchPathType = matchPathUntyped;
 [1] 54│ const withRouter: withRouterType = withRouterUntyped;
     55│
     56│ export {
     57│   BrowserRouter,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/modules/Route.js:15:37

Cannot assign ReactRouterRouteUntyped to ReactRouterRoute because:
 • function type [1] is incompatible with string [2] in the first argument of property history.block of the first
   argument of property render.
 • boolean [3] is incompatible with null or undefined [4] in the return value of the first argument of property
   history.block of the first argument of property render.
 • boolean [3] is incompatible with string [5] in the return value of the first argument of property history.block of
   the first argument of property render.
 • undefined [6] is incompatible with function type [7] in the return value of property history.block of the first
   argument of property render.
 • function type [1] is incompatible with string [2] in the first argument of property history.block of property
   children.
 • boolean [3] is incompatible with string [5] in the return value of property children of the first argument of
   property history.block.
 • boolean [3] is incompatible with string [5] in the return value of the first argument of property history.block of
   the first argument of property render.

        src/modules/Route.js
        12│
        13│ import type {ContextRouterType, RouteType} from '../types.js';
        14│
        15│ const ReactRouterRoute: RouteType = ReactRouterRouteUntyped;
        16│
        17│ const isEmptyChildren = (children: React.Node) =>
        18│   React.Children.count(children) === 0;

        flow-typed/npm/react-router-dom_v4.x.x.js
    [2] 73│       callback: | string // eslint-disable-line
 [4][5] 74│         | ((location: Location, action: HistoryAction) => ?string)
    [7] 75│     ): () => void,

        src/types.js
 [1][3] 80│     callback: (location: LocationType, action: HistoryActionType) => boolean
    [6] 81│   ): void,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/plugin.js:88:11

Cannot create Router element because:
 • inexact object type [1] is incompatible with exact object type [2] in property Provider.
 • function type [3] is incompatible with string [4] in the first argument of property Provider.history.block.
 • boolean [5] is incompatible with null or undefined [6] in the return value of the first argument of property
   Provider.history.block.
 • boolean [5] is incompatible with string [7] in the return value of the first argument of property
   Provider.history.block.
 • undefined [8] is incompatible with function type [9] in the return value of property Provider.history.block.
 • boolean [5] is incompatible with string [7] in the return value of the first argument of property block of property
   Provider.history.

        src/plugin.js
         85│         const history = createServerHistory(prefix, context, prefix + ctx.url);
         86│         myAPI.history = history;
         87│         ctx.element = (
         88│           <Router
         89│             history={history}
         90│             Provider={Provider}
         91│             onRoute={d => {
         92│               pageData = d;
         93│             }}
         94│             basename={prefix}
         95│             context={context}
         96│           >
         97│             {ctx.element}
         98│           </Router>
         99│         );
        100│         return next().then(() => {
        101│           ctx.template.body.push(

        flow-typed/npm/react-router-dom_v4.x.x.js
    [4]  73│       callback: | string // eslint-disable-line
 [6][7]  74│         | ((location: Location, action: HistoryAction) => ?string)
    [9]  75│     ): () => void,
           :
    [2] 126│   declare export var Router: React$ComponentType<{|
        127│     history: RouterHistory,
        128│     children?: React$Node,
        129│   |}>;

        src/types.js
 [3][5]  80│     callback: (location: LocationType, action: HistoryActionType) => boolean
    [8]  81│   ): void,
           :
    [1] 132│ export type RouterType = React.ComponentType<{
        133│   history: RouterHistoryType,
        134│   basename?: string,
        135│   children?: React.Node,
        136│ }>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/plugin.js:152:11

Cannot create Router element because:
 • inexact object type [1] is incompatible with exact object type [2] in property Provider.
 • function type [3] is incompatible with string [4] in the first argument of property Provider.history.block.
 • boolean [5] is incompatible with null or undefined [6] in the return value of the first argument of property
   Provider.history.block.
 • boolean [5] is incompatible with string [7] in the return value of the first argument of property
   Provider.history.block.
 • undefined [8] is incompatible with function type [9] in the return value of property Provider.history.block.
 • boolean [5] is incompatible with string [7] in the return value of the first argument of property block of property
   Provider.history.

        src/plugin.js
        149│         }
        150│         myAPI.history = browserHistory;
        151│         ctx.element = (
        152│           <Router
        153│             history={browserHistory}
        154│             Provider={Provider}
        155│             basename={ctx.prefix}
        156│             onRoute={payload => {
        157│               pageData = payload;
        158│               emitter && emitter.emit('pageview:browser', payload);
        159│             }}
        160│           >
        161│             {ctx.element}
        162│           </Router>
        163│         );
        164│         return next();
        165│       }

        flow-typed/npm/react-router-dom_v4.x.x.js
    [4]  73│       callback: | string // eslint-disable-line
 [6][7]  74│         | ((location: Location, action: HistoryAction) => ?string)
    [9]  75│     ): () => void,
           :
    [2] 126│   declare export var Router: React$ComponentType<{|
        127│     history: RouterHistory,
        128│     children?: React$Node,
        129│   |}>;

        src/types.js
 [3][5]  80│     callback: (location: LocationType, action: HistoryActionType) => boolean
    [8]  81│   ): void,
           :
    [1] 132│ export type RouterType = React.ComponentType<{
        133│   history: RouterHistoryType,
        134│   basename?: string,
        135│   children?: React.Node,
        136│ }>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/server.js:48:30

Cannot assign NavLinkUntyped to NavLink because in property to:
 • Either undefined [1] is incompatible with string [2].
 • Or undefined [1] is incompatible with LocationShape [3].

        src/server.js
        45│ const HashRouter: HashRouterType = HashRouterUntyped;
        46│ const Link: LinkType = LinkUntyped;
        47│ const MemoryRouter: MemoryRouterType = MemoryRouterUntyped;
        48│ const NavLink: NavLinkType = NavLinkUntyped;
        49│ const Prompt: PromptType = PromptUntyped;
        50│ const Switch: SwitchType = SwitchUntyped;
        51│ const matchPath: matchPathType = matchPathUntyped;

        flow-typed/npm/react-router-dom_v4.x.x.js
 [2][3] 29│     to: string | LocationShape,

        src/types.js
    [1] 52│   to?: string | LocationShapeType,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/server.js:52:19

Cannot use withRouterType [1] with fewer than 2 type arguments.

     49│ const Prompt: PromptType = PromptUntyped;
     50│ const Switch: SwitchType = SwitchUntyped;
     51│ const matchPath: matchPathType = matchPathUntyped;
 [1] 52│ const withRouter: withRouterType = withRouterUntyped;
     53│
     54│ export {
     55│   BrowserRouter,



Found 23 errors
```

