### PR TITLE
Resolve Flow complaints in fusion-cli

### DIFF
--- a/fusion-cli/.flowconfig
+++ b/fusion-cli/.flowconfig
@@ -1,11 +1,10 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
 <PROJECT_ROOT>/dist/.*
-.*/.fusion/.*
-.*/i18n/fixture/.*
 
 [include]
-../common/temp/node_modules
+../common/temp/node_module
+../../common/temp/node_modules
 
 [libs]
 ./node_modules/fusion-core/flow-typed

--- a/fusion-cli/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/fusion-cli/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,28 +1,27 @@
-// flow-typed signature: 5514042185f40bea708c7d73e53fabda
-// flow-typed version: be05cd918c/react-router-dom_v4.x.x/flow_>=v0.63.x
+// @flow
 
-declare module "react-router-dom" {
+declare module 'react-router-dom' {
   declare export var BrowserRouter: React$ComponentType<{|
     basename?: string,
     forceRefresh?: boolean,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
-    children?: React$Node
-  |}>
+    children?: React$Node,
+  |}>;
 
   declare export var HashRouter: React$ComponentType<{|
     basename?: string,
     getUserConfirmation?: GetUserConfirmation,
-    hashType?: "slash" | "noslash" | "hashbang",
-    children?: React$Node
-  |}>
+    hashType?: 'slash' | 'noslash' | 'hashbang',
+    children?: React$Node,
+  |}>;
 
   declare export var Link: React$ComponentType<{
     className?: string,
     to: string | LocationShape,
     replace?: boolean,
-    children?: React$Node
-  }>
+    children?: React$Node,
+  }>;
 
   declare export var NavLink: React$ComponentType<{
     to: string | LocationShape,
@@ -33,8 +32,8 @@ declare module "react-router-dom" {
     isActive?: (match: Match, location: Location) => boolean,
     children?: React$Node,
     exact?: boolean,
-    strict?: boolean
-  }>
+    strict?: boolean,
+  }>;
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-native types as well.
@@ -43,17 +42,17 @@ declare module "react-router-dom" {
     search: string,
     hash: string,
     state?: any,
-    key?: string
+    key?: string,
   };
 
   declare export type LocationShape = {
     pathname?: string,
     search?: string,
     hash?: string,
-    state?: any
+    state?: any,
   };
 
-  declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+  declare export type HistoryAction = 'PUSH' | 'REPLACE' | 'POP';
 
   declare export type RouterHistory = {
     length: number,
@@ -69,32 +68,33 @@ declare module "react-router-dom" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: string | (location: Location, action: HistoryAction) => ?string
+      callback: | string // eslint-disable-line
+        | ((location: Location, action: HistoryAction) => ?string)
     ): () => void,
     // createMemoryHistory
     index?: number,
-    entries?: Array<Location>
+    entries?: Array<Location>,
   };
 
   declare export type Match = {
-    params: { [key: string]: ?string },
+    params: {[key: string]: ?string},
     isExact: boolean,
     path: string,
-    url: string
+    url: string,
   };
 
   declare export type ContextRouter = {|
     history: RouterHistory,
     location: Location,
     match: Match,
-    staticContext?: StaticRouterContext
+    staticContext?: StaticRouterContext,
   |};
 
   declare type ContextRouterVoid = {
     history: RouterHistory | void,
     location: Location | void,
     match: Match | void,
-    staticContext?: StaticRouterContext | void
+    staticContext?: StaticRouterContext | void,
   };
 
   declare export type GetUserConfirmation = (
@@ -103,41 +103,41 @@ declare module "react-router-dom" {
   ) => void;
 
   declare export type StaticRouterContext = {
-    url?: string
+    url?: string,
   };
 
   declare export var StaticRouter: React$ComponentType<{|
     basename?: string,
     location?: string | Location,
     context: StaticRouterContext,
-    children?: React$Node
-  |}>
+    children?: React$Node,
+  |}>;
 
   declare export var MemoryRouter: React$ComponentType<{|
     initialEntries?: Array<LocationShape | string>,
     initialIndex?: number,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
-    children?: React$Node
-  |}>
+    children?: React$Node,
+  |}>;
 
-  declare export var Router: React$ComponentType<{|
+  declare export var Router: React$ComponentType<{
     history: RouterHistory,
-    children?: React$Node
-  |}>
+    children?: React$Node,
+  }>;
 
   declare export var Prompt: React$ComponentType<{|
     message: string | ((location: Location) => string | boolean),
-    when?: boolean
-  |}>
+    when?: boolean,
+  |}>;
 
   declare export var Redirect: React$ComponentType<{|
     to: string | LocationShape,
     push?: boolean,
     from?: string,
     exact?: boolean,
-    strict?: boolean
-  |}>
+    strict?: boolean,
+  |}>;
 
   declare export var Route: React$ComponentType<{|
     component?: React$ComponentType<*>,
@@ -147,21 +147,28 @@ declare module "react-router-dom" {
     exact?: boolean,
     strict?: boolean,
     location?: LocationShape,
-    sensitive?: boolean
-  |}>
+    sensitive?: boolean,
+  |}>;
 
   declare export var Switch: React$ComponentType<{|
     children?: React$Node,
-    location?: Location
-  |}>
+    location?: Location,
+  |}>;
 
-  declare export function withRouter<Props : {}, Component: React$ComponentType<Props>>(WrappedComponent: Component) : React$ComponentType<$Diff<React$ElementConfig<$Supertype<Component>>, ContextRouterVoid>>;
+  declare export function withRouter<
+    Props: {},
+    Component: React$ComponentType<Props>
+  >(
+    WrappedComponent: Component
+  ): React$ComponentType<
+    $Diff<React$ElementConfig<Component>, ContextRouterVoid>
+  >;
 
   declare type MatchPathOptions = {
     path?: string,
     exact?: boolean,
     sensitive?: boolean,
-    strict?: boolean
+    strict?: boolean,
   };
 
   declare export function matchPath(
@@ -170,5 +177,8 @@ declare module "react-router-dom" {
     parent?: Match
   ): null | Match;
 
-  declare export function generatePath(pattern?: string, params?: Object): string;
+  declare export function generatePath(
+    pattern?: string,
+    params?: Object
+  ): string;
 }


### PR DESCRIPTION
Resolves the following Flow complaints:

```sh
$ flow check
Skipping /Users/amsmith/Code/private/fusionjs/public/common/temp/node_modules: No such file or directory

Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/react-router-dom_v4.x.x.js:158:166

Deprecated utility. Using $Supertype types is not recommended! (deprecated-utility)

     155│     location?: Location
     156│   |}>
     157│
     158│   declare export function withRouter<Props : {}, Component: React$ComponentType<Props>>(WrappedComponent: Component) : React$ComponentType<$Diff<React$ElementConfig<$Supertype<Component>>, ContextRouterVoid>>;
     159│
     160│   declare type MatchPathOptions = {
     161│     path?: string,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../../common/temp/node_modules/graphql/execution/execute.js.flow:10:39

Cannot resolve module iterall.

      7│  * @flow strict
      8│  */
      9│
     10│ import { forEach, isCollection } from 'iterall';
     11│ import { GraphQLError } from '../error/GraphQLError';
     12│ import { locatedError } from '../error/locatedError';
     13│ import inspect from '../jsutils/inspect';


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../../common/temp/node_modules/graphql/utilities/astFromValue.js.flow:10:39

Cannot resolve module iterall.

      7│  * @flow strict
      8│  */
      9│
     10│ import { forEach, isCollection } from 'iterall';
     11│
     12│ import objectValues from '../polyfills/objectValues';
     13│ import inspect from '../jsutils/inspect';


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../../common/temp/node_modules/graphql/utilities/coerceValue.js.flow:10:39

Cannot resolve module iterall.

      7│  * @flow strict
      8│  */
      9│
     10│ import { forEach, isCollection } from 'iterall';
     11│ import objectValues from '../polyfills/objectValues';
     12│ import inspect from '../jsutils/inspect';
     13│ import isInvalid from '../jsutils/isInvalid';


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../fusion-plugin-react-router/src/plugin.js:88:12

Cannot create Router element because inexact object type [1] is incompatible with exact object type [2] in property
Provider.

     ../fusion-plugin-react-router/src/plugin.js
      85│         const history = createServerHistory(prefix, context, prefix + ctx.url);
      86│         myAPI.history = history;
      87│         ctx.element = (
      88│           <Router
      89│             history={history}
      90│             Provider={Provider}
      91│             onRoute={d => {
      92│               pageData = d;
      93│             }}
      94│             basename={prefix}
      95│             context={context}
      96│           >
      97│             {ctx.element}
      98│           </Router>
      99│         );
     100│         return next().then(() => {
     101│           ctx.template.body.push(

     flow-typed/npm/react-router-dom_v4.x.x.js
 [2] 124│   declare export var Router: React$ComponentType<{|
     125│     history: RouterHistory,
     126│     children?: React$Node
     127│   |}>

     ../fusion-plugin-react-router/src/types.js
 [1] 133│ export type RouterType = React.ComponentType<{
     134│   history: RouterHistoryType,
     135│   basename?: string,
     136│   children?: React.Node,
     137│ }>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../fusion-plugin-react-router/src/plugin.js:152:12

Cannot create Router element because inexact object type [1] is incompatible with exact object type [2] in property
Provider.

     ../fusion-plugin-react-router/src/plugin.js
     149│         }
     150│         myAPI.history = browserHistory;
     151│         ctx.element = (
     152│           <Router
     153│             history={browserHistory}
     154│             Provider={Provider}
     155│             basename={ctx.prefix}
     156│             onRoute={payload => {
     157│               pageData = payload;
     158│               emitter && emitter.emit('pageview:browser', payload);
     159│             }}
     160│           >
     161│             {ctx.element}
     162│           </Router>
     163│         );
     164│         return next();
     165│       }

     flow-typed/npm/react-router-dom_v4.x.x.js
 [2] 124│   declare export var Router: React$ComponentType<{|
     125│     history: RouterHistory,
     126│     children?: React$Node
     127│   |}>

     ../fusion-plugin-react-router/src/types.js
 [1] 133│ export type RouterType = React.ComponentType<{
     134│   history: RouterHistoryType,
     135│   basename?: string,
     136│   children?: React.Node,
     137│ }>;



Found 6 errors
```