### PR TITLE
Fix bug with default values for transform

### DIFF
--- a/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/src/main.js
+++ b/fusion-cli/test/e2e/transpile-node-modules-extended/fixture/src/main.js
@@ -1,10 +1,10 @@
-// @noflow
+// @flow
 import App from 'fusion-core';
 
 import fixture from 'fixture-es2017-pkg';
 import other from 'fixture-macro-pkg';
 
-export default async function() {
+export default async function(args: any) {
   const app = new App('element', el => el);
   fixture();
   other();


### PR DESCRIPTION
The default value for transform should be 'all' if running on 'src/' code and 'spec' when running on node_modules (except for an exception in fusion-cli). This fixes a bug where the default was being set to 'spec' for all code. 