### PR TITLE
Add HTML 'lang' attribute for improved i18n accessibility

### DIFF
--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -65,14 +65,14 @@ test('ssr', async t => {
     headers: {'accept-language': 'en-US'},
     element: 'test',
     // $FlowFixMe - Invalid context
-    template: {body: []},
+    template: {htmlAttrs: {}, body: []},
     memoized: new Map(),
   };
   const deps = {
     loader: {from: () => ({translations: data, locale: 'en-US'})},
   };
 
-  t.plan(3);
+  t.plan(4);
   if (!I18n.provides) {
     t.end();
     return;
@@ -92,6 +92,7 @@ test('ssr', async t => {
   );
   // $FlowFixMe
   t.equals(consumeSanitizedHTML(ctx.template.body[0]).match('</div>'), null);
+  t.equals(ctx.template.htmlAttrs['lang'], 'en-US');
 
   chunkTranslationMap.dispose('a.js', [0], Object.keys(data));
   chunkTranslationMap.translations.clear();

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -94,6 +94,10 @@ const pluginFactory: () => PluginType = () =>
             </script>
           `; // consumed by ./browser
           ctx.template.body.push(script);
+
+          // set HTML lang tag as a hint for signal screen readers to switch to the
+          // recommended language.
+          ctx.template.htmlAttrs['lang'] = localeCode;
         } else if (ctx.path === '/_translations') {
           const i18n = plugin.from(ctx);
           const ids = querystring.parse(ctx.querystring).ids || '';


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusionjs/issues/293.

For context, the `lang` attribute provides a hint on the language of the text on the web page (or specific elements) for signal screen readers.  For more details, check out [language tags in HTML](https://accessibility.psu.edu/foreignlanguages/langtaghtml/).