### PR TITLE
Upgrade legacy context [fusion-plugin-i18n-react]

### DIFF
--- a/fusion-plugin-i18n-react/src/__tests__/__snapshots__/translate.test.browser.js.snap
+++ b/fusion-plugin-i18n-react/src/__tests__/__snapshots__/translate.test.browser.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Translate 1`] = `"<div>foo bar baz</div>"`;

--- a/fusion-plugin-i18n-react/src/__tests__/translate.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/translate.test.browser.js
@@ -3,18 +3,17 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {withTranslations} from '../index';
+import {Translate} from '../index';
 import {I18nContext} from '../plugin.js';
 
-test('withTranslations() HOC - localeCode', () => {
-  const Foo = withTranslations([])(({localeCode, translate}) => {
+test('Translate', () => {
+  const Foo = () => {
     return (
       <div>
-        {localeCode}
-        {translate()}
+        <Translate id={'foo'} />
       </div>
     );
-  });
+  };
 
   const mockI18n = {
     localeCode: 'fr_CA',

--- a/fusion-plugin-i18n-react/src/__tests__/translate.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/translate.test.browser.js
@@ -16,6 +16,7 @@ test('Translate', () => {
   };
 
   const mockI18n = {
+    async load() {},
     localeCode: 'fr_CA',
     translate() {
       return 'foo bar baz';

--- a/fusion-plugin-i18n-react/src/__tests__/with-translations.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/with-translations.test.browser.js
@@ -5,23 +5,7 @@ import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 
 import {withTranslations} from '../index';
-
-function mockProvider(i18n) {
-  class I18NProvider extends Component<*, *> {
-    getChildContext() {
-      return {i18n};
-    }
-    render() {
-      return React.Children.only(this.props.children);
-    }
-  }
-
-  I18NProvider.childContextTypes = {
-    i18n: PropTypes.object.isRequired,
-  };
-
-  return I18NProvider;
-}
+import {I18nContext} from '../plugin.js'
 
 test('withTranslations() HOC - localeCode', () => {
   const Foo = withTranslations([])(({localeCode, translate}) => {
@@ -33,18 +17,18 @@ test('withTranslations() HOC - localeCode', () => {
     );
   });
 
-  const Provider = mockProvider({
+  const mockI18n = {
     localeCode: 'fr_CA',
     translate() {
       return 'foo bar baz';
     },
-  });
+  };
 
   expect(
     mount(
-      <Provider>
+      <I18nContext.Provider value={mockI18n}>
         <Foo />
-      </Provider>
+      </I18nContext.Provider>
     ).html()
   ).toMatchSnapshot();
 });

--- a/fusion-plugin-i18n-react/src/__tests__/with-translations.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/with-translations.test.browser.js
@@ -17,6 +17,7 @@ test('withTranslations() HOC - localeCode', () => {
   });
 
   const mockI18n = {
+    async load() {},
     localeCode: 'fr_CA',
     translate() {
       return 'foo bar baz';

--- a/fusion-plugin-i18n-react/src/plugin.js
+++ b/fusion-plugin-i18n-react/src/plugin.js
@@ -13,11 +13,12 @@ import i18n, {I18nToken} from 'fusion-plugin-i18n';
 import type {I18nDepsType, I18nServiceType} from 'fusion-plugin-i18n';
 import {FusionContext, ProviderPlugin, useService} from 'fusion-react';
 
-export const I18nContext = React.createContext(() => {
-  throw new Error(
-    'Attempting to use i18n Context without registering Fusion.js plugin from `fusion-plugin-i18n-react`'
-  );
-});
+type ExtractReturnType = <V, TArg>((arg: TArg) => V) => V;
+export type I18nType = $Call<
+  ExtractReturnType,
+  $PropertyType<I18nServiceType, 'from'>
+>;
+export const I18nContext = React.createContext<I18nType>({});
 
 /**
  * The i18n service is loaded with the fusion ctx and provided to the
@@ -27,7 +28,8 @@ export const I18nContext = React.createContext(() => {
  */
 function BundleSplitConsumer(props, {splitComponentLoaders}) {
   const ctx = React.useContext(FusionContext);
-  const i18n = useService(I18nToken).from(ctx);
+  const service: I18nServiceType = useService(I18nToken);
+  const i18n = service.from(ctx);
   React.useMemo(() => {
     // `splitComponentLoaders` comes from fusion-react/async/prepare-provider
     // `ids` comes from fusion-react/async/split

--- a/fusion-plugin-i18n-react/src/translate.js
+++ b/fusion-plugin-i18n-react/src/translate.js
@@ -7,27 +7,18 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import i18n from 'fusion-plugin-i18n';
+import {I18nContext} from './plugin.js';
 
 type TranslatePropsType = {
   id: string,
   data?: Object,
 };
 
-type TranslateContextType = {
-  i18n?: typeof i18n.provides,
-};
-
-function Translate(props: TranslatePropsType, context: TranslateContextType) {
-  const content =
-    (context.i18n && context.i18n.translate(props.id, props.data)) || props.id;
+function Translate(props: TranslatePropsType) {
+  const i18n = React.useContext(I18nContext);
+  const content = (i18n && i18n.translate(props.id, props.data)) || props.id;
   return React.Fragment ? <>{content}</> : <span>{content}</span>;
 }
-
-Translate.contextTypes = {
-  i18n: PropTypes.object,
-};
 
 export {Translate};

--- a/fusion-plugin-i18n-react/src/with-translations.js
+++ b/fusion-plugin-i18n-react/src/with-translations.js
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import type {Context} from 'fusion-core';
 import {I18nContext} from './plugin.js';
 

--- a/fusion-plugin-i18n-react/src/with-translations.js
+++ b/fusion-plugin-i18n-react/src/with-translations.js
@@ -9,6 +9,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import type {Context} from 'fusion-core';
+import {I18nContext} from './plugin.js';
 
 type TranslateType = (
   key: string,
@@ -40,7 +41,7 @@ export const withTranslations = (
 
       constructor(props: T, context: Context) {
         super(props, context);
-        const {i18n} = context;
+        const i18n = this.context;
         this.localeCode = i18n ? i18n.localeCode : 'en_US';
         this.translate = i18n
           ? (key: string, interpolations?: {[string]: string | number}) =>
@@ -61,9 +62,7 @@ export const withTranslations = (
 
     const displayName = Component.displayName || Component.name || 'Anonymous';
     WithTranslations.displayName = `withTranslations(${displayName})`;
-    WithTranslations.contextTypes = {
-      i18n: PropTypes.object.isRequired,
-    };
+    WithTranslations.contextType = I18nContext;
 
     return WithTranslations;
   };

--- a/fusion-plugin-i18n-react/src/with-translations.js
+++ b/fusion-plugin-i18n-react/src/with-translations.js
@@ -61,6 +61,7 @@ export const withTranslations = (
 
     const displayName = Component.displayName || Component.name || 'Anonymous';
     WithTranslations.displayName = `withTranslations(${displayName})`;
+    // $FlowFixMe
     WithTranslations.contextType = I18nContext;
 
     return WithTranslations;

--- a/fusion-plugin-i18n-react/src/with-translations.js
+++ b/fusion-plugin-i18n-react/src/with-translations.js
@@ -41,7 +41,7 @@ export const withTranslations = (
 
       constructor(props: T, context: Context) {
         super(props, context);
-        const i18n = this.context;
+        const i18n = context;
         this.localeCode = i18n ? i18n.localeCode : 'en_US';
         this.translate = i18n
           ? (key: string, interpolations?: {[string]: string | number}) =>


### PR DESCRIPTION
Upgrade legacy context

We still want to require users to register the plugin from this package so that the `splitComponentLoaders` callback is registered