### PR TITLE
Add logic for limiting the number of events sent in each batch

### DIFF
--- a/fusion-plugin-universal-events/src/storage/__tests__/storage-test.browser.js
+++ b/fusion-plugin-universal-events/src/storage/__tests__/storage-test.browser.js
@@ -55,6 +55,23 @@ Object.keys(toBeTested).forEach(storageType => {
       t.end();
     });
 
+    t.test('getAndClear with limit', t => {
+      const data = {type: 'nick', payload: 'test'};
+      getAndClear();
+      add(data);
+      add(data);
+      add(data);
+
+      t.deepEqual(
+        getAndClear(2),
+        [data, data],
+        'getAndClear should get current array with limit'
+      );
+      t.deepEqual(getAndClear(), [data], 'should clear with limit correctly');
+      t.notOk(getAndClear().length, 'finally is cleared');
+      t.end();
+    });
+
     t.end();
   });
 });

--- a/fusion-plugin-universal-events/src/storage/in-memory.js
+++ b/fusion-plugin-universal-events/src/storage/in-memory.js
@@ -1,9 +1,10 @@
 // @flow
 
 import type {BatchStorage, BatchType} from '../types';
+import {split} from './split';
 
 class InMemoryBatchStorage implements BatchStorage {
-  data = [];
+  data: BatchType[] = [];
 
   add = (...toBeAdded: BatchType[]) => {
     this.data.push(...toBeAdded);
@@ -13,10 +14,11 @@ class InMemoryBatchStorage implements BatchStorage {
     this.data.unshift(...toBeAdded);
   };
 
-  getAndClear = () => {
-    const events = this.data;
-    this.data = [];
-    return events;
+  getAndClear = (limit?: number = Infinity): BatchType[] => {
+    const allEvents = this.data;
+    const [eventsToSend, eventsToStore] = split(allEvents, limit);
+    this.data = eventsToStore;
+    return eventsToSend;
   };
 }
 

--- a/fusion-plugin-universal-events/src/storage/local-storage.js
+++ b/fusion-plugin-universal-events/src/storage/local-storage.js
@@ -3,6 +3,7 @@
 
 import type {BatchType, BatchStorage} from '../types';
 import {inMemoryBatchStorage} from './in-memory';
+import {split} from './split';
 
 const storageKey = 'fusion-events';
 
@@ -12,14 +13,6 @@ const get = () => {
     return Array.isArray(events) ? events : [];
   } catch (e) {
     return [];
-  }
-};
-
-const clear = () => {
-  try {
-    window.localStorage.removeItem(storageKey);
-  } catch (e) {
-    // do nothing
   }
 };
 
@@ -40,10 +33,11 @@ class LocalBatchStorage implements BatchStorage {
     set(toBeAdded.concat(get()));
   };
 
-  getAndClear = () => {
-    const events = get();
-    clear();
-    return events;
+  getAndClear = (limit?: number = Infinity): BatchType[] => {
+    const allEvents = get();
+    const [eventsToSend, eventsToStore] = split(allEvents, limit);
+    set(eventsToStore);
+    return eventsToSend;
   };
 }
 

--- a/fusion-plugin-universal-events/src/storage/split.js
+++ b/fusion-plugin-universal-events/src/storage/split.js
@@ -1,0 +1,9 @@
+// @flow
+export function split<T>(arr: Array<T>, index: number): [Array<T>, Array<T>] {
+  if (arr.length < index) {
+    return [arr, []];
+  }
+  const a = arr.slice(0, index);
+  const b = arr.slice(index);
+  return [a, b];
+}

--- a/fusion-plugin-universal-events/src/types.js
+++ b/fusion-plugin-universal-events/src/types.js
@@ -41,7 +41,7 @@ export type BatchType = {|
 export interface BatchStorage {
   add(toBeAdded: BatchType): void;
   addToStart(toBeAdded: BatchType): void;
-  getAndClear(): BatchType[];
+  getAndClear(limit: number): BatchType[];
 }
 
 export type UniversalEventsPluginDepsType = {


### PR DESCRIPTION
koa-bodyparser puts a limit on the size of the request body it will parse to help prevent a DOS attack. If lots of events are sent at once from the universal-events plugin, the request body can exceed this limit. Since we have error handling logic that puts these events into local storage, this can put the user into an infinite cycle of failed requests as the events in local storage grow. 

This PR addresses this by putting a limit on the number of events which can be sent in a single batch. If the response fails with a 413 status code, we cut that limit in half for the current session.