### PR TITLE
Move sourcemap install into entry files

### DIFF
--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -501,17 +501,6 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
       runtime === 'server' &&
         new webpack.BannerPlugin({
           raw: true,
-          entryOnly: false,
-          // source-map-support is a dep of framework, so we need to resolve this path
-          banner: `require('${require
-            .resolve('source-map-support')
-            // replace windows backslashes since this is generated code (#461)
-            .split(path.sep)
-            .join('/')}').install();`,
-        }),
-      runtime === 'server' &&
-        new webpack.BannerPlugin({
-          raw: true,
           entryOnly: true,
           // Enforce NODE_ENV at runtime
           banner: getEnvBanner(env),

--- a/fusion-cli/entries/server-entry.js
+++ b/fusion-cli/entries/server-entry.js
@@ -9,7 +9,8 @@
 /* eslint-env node */
 
 /* eslint-disable import/first */
-require('source-map-support').install();
+import sourceMapSupport from 'source-map-support';
+sourceMapSupport.install();
 
 // $FlowFixMe
 import '__SECRET_I18N_MANIFEST_INSTRUMENTATION_LOADER__!'; // eslint-disable-line

--- a/fusion-cli/entries/server-entry.js
+++ b/fusion-cli/entries/server-entry.js
@@ -8,6 +8,9 @@
 
 /* eslint-env node */
 
+/* eslint-disable import/first */
+require('source-map-support').install();
+
 // $FlowFixMe
 import '__SECRET_I18N_MANIFEST_INSTRUMENTATION_LOADER__!'; // eslint-disable-line
 

--- a/fusion-cli/entries/server-entry.js
+++ b/fusion-cli/entries/server-entry.js
@@ -10,6 +10,7 @@
 
 /* eslint-disable import/first */
 import sourceMapSupport from 'source-map-support';
+
 sourceMapSupport.install();
 
 // $FlowFixMe

--- a/fusion-cli/entries/serverless-entry.js
+++ b/fusion-cli/entries/serverless-entry.js
@@ -9,7 +9,8 @@
 /* eslint-env node */
 
 /* eslint-disable import/first */
-require('source-map-support').install();
+import sourceMapSupport from 'source-map-support';
+sourceMapSupport.install();
 
 // $FlowFixMe
 import '__SECRET_I18N_MANIFEST_INSTRUMENTATION_LOADER__!'; // eslint-disable-line

--- a/fusion-cli/entries/serverless-entry.js
+++ b/fusion-cli/entries/serverless-entry.js
@@ -8,6 +8,9 @@
 
 /* eslint-env node */
 
+/* eslint-disable import/first */
+require('source-map-support').install();
+
 // $FlowFixMe
 import '__SECRET_I18N_MANIFEST_INSTRUMENTATION_LOADER__!'; // eslint-disable-line
 

--- a/fusion-cli/entries/serverless-entry.js
+++ b/fusion-cli/entries/serverless-entry.js
@@ -10,6 +10,7 @@
 
 /* eslint-disable import/first */
 import sourceMapSupport from 'source-map-support';
+
 sourceMapSupport.install();
 
 // $FlowFixMe


### PR DESCRIPTION
This will allow for all imports to be affected by `experimentalBundleTest`, which is necessary for now.sh deployments to work.