### PR TITLE
Remove orphaned-plugin exception

### DIFF
--- a/fusion-core/src/__tests__/dependency-resolution.js
+++ b/fusion-core/src/__tests__/dependency-resolution.js
@@ -610,30 +610,6 @@ tape('error message when dependent plugin does not have token', t => {
   t.end();
 });
 
-tape('Extraneous dependencies', t => {
-  const app = new App('el', el => el);
-  const TestToken = createToken('test');
-  app.register(TestToken, 'some-value');
-  t.throws(() => app.resolve());
-  t.end();
-});
-
-tape('Extraneous dependencies after re-registering', t => {
-  const app = new App('el', el => el);
-  const TokenA = createToken('A');
-  const TokenB = createToken('B');
-  app.register(
-    TokenA,
-    createPlugin({
-      deps: {b: TokenB},
-    })
-  );
-  app.register(TokenB, 'test');
-  app.register(TokenA, createPlugin({}));
-  t.doesNotThrow(() => app.resolve());
-  t.end();
-});
-
 tape('Missing token errors reasonably', t => {
   const app = new App('el', el => el);
   // $FlowFixMe

--- a/fusion-core/src/__tests__/enhance.js
+++ b/fusion-core/src/__tests__/enhance.js
@@ -63,49 +63,6 @@ tape('enhancement with a plugin', t => {
   app.resolve();
 });
 
-tape('enhancement with a plugin allows orphan plugins', t => {
-  const app = new App('el', el => el);
-
-  type FnType = string => string;
-  const FnToken: Token<FnType> = createToken('FnType');
-  const BaseFn: FnType = a => a;
-  const BaseFnEnhancer = (fn: FnType): FusionPlugin<void, FnType> => {
-    return createPlugin({
-      provides: () => {
-        return arg => {
-          return fn(arg) + ' enhanced';
-        };
-      },
-    });
-  };
-  app.register(FnToken, BaseFn);
-  app.enhance(FnToken, BaseFnEnhancer);
-  t.doesNotThrow(() => {
-    app.resolve();
-  });
-  t.end();
-});
-
-tape(
-  'enhancement with a non-plugin enhancer does not allow orphan plugins',
-  t => {
-    const app = new App('el', el => el);
-
-    type FnType = string => string;
-    const FnToken: Token<FnType> = createToken('FnType');
-    const BaseFn: FnType = a => a;
-    const BaseFnEnhancer = (fn: FnType): FnType => {
-      return fn;
-    };
-    app.register(FnToken, BaseFn);
-    app.enhance(FnToken, BaseFnEnhancer);
-    t.throws(() => {
-      app.resolve();
-    });
-    t.end();
-  }
-);
-
 tape('enhancement with a plugin with deps', t => {
   const app = new App('el', el => el);
 


### PR DESCRIPTION
- don't track nonPlugins
- remove error tests

With the implementation of `useService`, plugins that supply React context must be registered to a token. Previously, this wasn't required.

We currently have no way of tracking the relationship between plugins and components, it's purely enforced during rendering since `useService` will throw if the plugin was not registered. We couldn't suspend throwing an error until rendering is complete since not every component is rendered.

The only purpose this exception served was to make you aware of whether you needed a token or not. Supplying a token and not using it has no effect on the application's correctness.

Previous work:
- https://github.com/fusionjs/fusion-core/pull/331
- https://github.com/fusionjs/fusion-core/pull/119 (`old and busted, new hotness`)