### PR TITLE
Support dynamic translations

### DIFF
--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -57,7 +57,7 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
           const translationPaths =
             refPath.parentPath.scope.bindings[localName].referencePaths;
           translationPaths.forEach(translationPath => {
-            if (t.isCallExpression(translationPath.parentPath)) {
+            if (t.isCallExpression(translationPath.parentPath) && translationPath.parentKey === 'callee') {
               const arg = translationPath.parentPath.node.arguments[0];
               const errorMessage =
                 'useTranslations result function must be passed string literal or hinted template literal';
@@ -74,6 +74,8 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
               } else {
                 throw new Error(errorMessage);
               }
+            } else {
+              throw new Error('Unexpected usage of useTranslations return function');
             }
           });
         }

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -51,13 +51,18 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
           });
         } else if (specifierName === 'useTranslations') {
           if (!t.isVariableDeclarator(refPath.parentPath.parent)) {
-            throw new Error('Unexpected assignment of useTranslations return function');
+            throw new Error(
+              'Unexpected assignment of useTranslations return function'
+            );
           }
           const localName = refPath.parentPath.parent.id.name;
           const translationPaths =
             refPath.parentPath.scope.bindings[localName].referencePaths;
           translationPaths.forEach(translationPath => {
-            if (t.isCallExpression(translationPath.parentPath) && translationPath.parentKey === 'callee') {
+            if (
+              t.isCallExpression(translationPath.parentPath) &&
+              translationPath.parentKey === 'callee'
+            ) {
               const arg = translationPath.parentPath.node.arguments[0];
               const errorMessage =
                 'useTranslations result function must be passed string literal or hinted template literal';
@@ -75,7 +80,9 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
                 throw new Error(errorMessage);
               }
             } else {
-              throw new Error('Unexpected usage of useTranslations return function');
+              throw new Error(
+                'Unexpected usage of useTranslations return function'
+              );
             }
           });
         }

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -69,25 +69,12 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
               if (t.isStringLiteral(arg)) {
                 translationIds.add(arg.value);
               } else if (t.isTemplateLiteral(arg)) {
-                const result = arg.quasis
-                  .map(q => q.value.cooked)
-                  .filter((str, index) => {
-                    if (
-                      index !== 0 &&
-                      index !== arg.quasis.length - 1 &&
-                      str === ''
-                    ) {
-                      // interpolations in the middle of a string can be ignored
-                      // there is no guarantee that they will evaluate to a string of any length
-                      return false;
-                    }
-                    return true;
-                  });
-                if (result.join('') === '') {
+                const literalSections = arg.quasis.map(q => q.value.cooked);
+                if (literalSections.join('') === '') {
                   // template literal not hinted, i.e. translate(`${foo}`)
                   throw new Error(errorMessage);
                 } else {
-                  translationIds.add(result);
+                  translationIds.add(literalSections);
                 }
               } else {
                 throw new Error(errorMessage);

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -69,7 +69,20 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
               if (t.isStringLiteral(arg)) {
                 translationIds.add(arg.value);
               } else if (t.isTemplateLiteral(arg)) {
-                const result = arg.quasis.map(q => q.value.cooked);
+                const result = arg.quasis
+                  .map(q => q.value.cooked)
+                  .filter((str, index) => {
+                    if (
+                      index !== 0 &&
+                      index !== arg.quasis.length - 1 &&
+                      str === ''
+                    ) {
+                      // interpolations in the middle of a string can be ignored
+                      // there is no guarantee that they will evaluate to a string of any length
+                      return false;
+                    }
+                    return true;
+                  });
                 if (result.join('') === '') {
                   // template literal not hinted, i.e. translate(`${foo}`)
                   throw new Error(errorMessage);

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -11,7 +11,7 @@
 const createModuleVisitor = require('../babel-plugin-utils/visit-named-module');
 
 const PACKAGE_NAME = ['fusion-plugin-i18n-react', 'fusion-plugin-i18n-preact'];
-const COMPONENT_IDENTIFIER = ['Translate', 'withTranslations'];
+const COMPONENT_IDENTIFIER = ['Translate', 'withTranslations', 'useTranslations'];
 
 module.exports = i18nPlugin;
 
@@ -43,6 +43,16 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
             if (!t.isStringLiteral(element)) {
               throw new Error(errorMessage);
             }
+            translationIds.add(element.value);
+          });
+        } else if (specifierName === 'useTranslations') {
+          const errorMessage =
+            'The useTranslations hook must be called with an array of strings';
+          if (!t.isArrayExpression(firstArg)) {
+            throw new Error(errorMessage);
+          }
+          const elements = firstArg.elements;
+          elements.forEach(element => {
             translationIds.add(element.value);
           });
         }

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -69,7 +69,7 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
               if (t.isStringLiteral(arg)) {
                 translationIds.add(arg.value);
               } else if (t.isTemplateLiteral(arg)) {
-                const result = arg.quasis.map(q => q.value.raw);
+                const result = arg.quasis.map(q => q.value.cooked);
                 if (result.join('') === '') {
                   // template literal not hinted, i.e. translate(`${foo}`)
                   throw new Error(errorMessage);

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -11,7 +11,11 @@
 const createModuleVisitor = require('../babel-plugin-utils/visit-named-module');
 
 const PACKAGE_NAME = ['fusion-plugin-i18n-react', 'fusion-plugin-i18n-preact'];
-const COMPONENT_IDENTIFIER = ['Translate', 'withTranslations', 'useTranslations'];
+const COMPONENT_IDENTIFIER = [
+  'Translate',
+  'withTranslations',
+  'useTranslations',
+];
 
 module.exports = i18nPlugin;
 
@@ -47,11 +51,13 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
           });
         } else if (specifierName === 'useTranslations') {
           const localName = refPath.parentPath.parent.id.name;
-          const translationPaths = refPath.parentPath.scope.bindings[localName].referencePaths;
+          const translationPaths =
+            refPath.parentPath.scope.bindings[localName].referencePaths;
           translationPaths.forEach(translationPath => {
             if (t.isCallExpression(translationPath.parentPath)) {
               const arg = translationPath.parentPath.node.arguments[0];
-              const errorMessage = 'useTranslations result function must be passed string literal or hinted template literal';
+              const errorMessage =
+                'useTranslations result function must be passed string literal or hinted template literal';
               if (t.isStringLiteral(arg)) {
                 translationIds.add(arg.value);
               } else if (t.isTemplateLiteral(arg)) {
@@ -96,4 +102,3 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
 
   return {visitor};
 }
-

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/index.js
@@ -50,6 +50,9 @@ function i18nPlugin(babel /*: Object */, {translationIds} /*: PluginOpts */) {
             translationIds.add(element.value);
           });
         } else if (specifierName === 'useTranslations') {
+          if (!t.isVariableDeclarator(refPath.parentPath.parent)) {
+            throw new Error('Unexpected assignment of useTranslations return function');
+          }
           const localName = refPath.parentPath.parent.id.name;
           const translationPaths =
             refPath.parentPath.scope.bindings[localName].referencePaths;

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
@@ -1,9 +1,9 @@
 // @flow
-const {transformSync} = require('@babel/core');
+const { transformSync } = require("@babel/core");
 
-const plugin = require('../');
+const plugin = require("../");
 
-test('babel-plugin-i18n', () => {
+test("babel-plugin-i18n", () => {
   const translationIds = new Set();
   const output = transformSync(
     `
@@ -15,25 +15,25 @@ export default function() {
   `,
     {
       parserOpts: {
-        plugins: ['jsx'],
+        plugins: ["jsx"]
       },
-      plugins: [[plugin, {translationIds}]],
+      plugins: [[plugin, { translationIds }]]
     }
   );
   expect(translationIds).toMatchInlineSnapshot(`
-        Set {
-          "test",
-        }
-    `);
+                Set {
+                  "test",
+                }
+        `);
   expect(output.code).toMatchInlineSnapshot(`
-    "import { Translate } from 'fusion-plugin-i18n-react';
-    export default function () {
-      return <Translate random={'test'} id=\\"test\\" />;
-    }"
-  `);
+            "import { Translate } from 'fusion-plugin-i18n-react';
+            export default function () {
+              return <Translate random={'test'} id=\\"test\\" />;
+            }"
+      `);
 });
 
-test('babel-plugin-i18n - invalid usage of <Translate>', () => {
+test("babel-plugin-i18n - invalid usage of <Translate>", () => {
   const translationIds = new Set();
   expect(() =>
     transformSync(
@@ -46,10 +46,64 @@ export default function() {
   `,
       {
         parserOpts: {
-          plugins: ['jsx'],
+          plugins: ["jsx"]
         },
-        plugins: [[plugin, {translationIds}]],
+        plugins: [[plugin, { translationIds }]]
       }
     )
-  ).toThrow('The translate component must have props.id be a string literal.');
+  ).toThrow("The translate component must have props.id be a string literal.");
+});
+
+test("babel-plugin-i18n - valid usage of useTranslations", () => {
+  const translationIds = new Set();
+  const output = transformSync(
+    `
+import {useTranslations} from 'fusion-plugin-i18n-react'; 
+
+export default function() {
+  const translate = useTranslations();
+  translate('static');
+  translate(\`dynamic.\${foo}\`);
+}
+  `,
+    {
+      plugins: [[plugin, { translationIds }]]
+    }
+  );
+  expect(translationIds).toMatchInlineSnapshot(`
+    Set {
+      "static",
+      Array [
+        "dynamic.",
+        "",
+      ],
+    }
+  `);
+  expect(output.code).toMatchInlineSnapshot(`
+        "import { useTranslations } from 'fusion-plugin-i18n-react';
+        export default function () {
+          const translate = useTranslations();
+          translate('static');
+          translate(\`dynamic.\${foo}\`);
+        }"
+    `);
+});
+
+test("babel-plugin-i18n - invalid usage of useTranslations", () => {
+  const translationIds = new Set();
+  expect(() =>
+    transformSync(
+    `
+import {useTranslations} from 'fusion-plugin-i18n-react'; 
+
+export default function() {
+  const translate = useTranslations();
+  translate(foo);
+}
+  `,
+      {
+        plugins: [[plugin, { translationIds }]]
+      }
+    )
+  ).toThrow("useTranslations result function must be passed string literal or hinted template literal");
 });

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
@@ -21,16 +21,16 @@ export default function() {
     }
   );
   expect(translationIds).toMatchInlineSnapshot(`
-                Set {
-                  "test",
-                }
-        `);
+    Set {
+      "test",
+    }
+  `);
   expect(output.code).toMatchInlineSnapshot(`
-            "import { Translate } from 'fusion-plugin-i18n-react';
-            export default function () {
-              return <Translate random={'test'} id=\\"test\\" />;
-            }"
-      `);
+    "import { Translate } from 'fusion-plugin-i18n-react';
+    export default function () {
+      return <Translate random={'test'} id=\\"test\\" />;
+    }"
+  `);
 });
 
 test('babel-plugin-i18n - invalid usage of <Translate>', () => {
@@ -80,13 +80,13 @@ export default function() {
     }
   `);
   expect(output.code).toMatchInlineSnapshot(`
-        "import { useTranslations } from 'fusion-plugin-i18n-react';
-        export default function () {
-          const translate = useTranslations();
-          translate('static');
-          translate(\`dynamic.\${foo}\`);
-        }"
-    `);
+    "import { useTranslations } from 'fusion-plugin-i18n-react';
+    export default function () {
+      const translate = useTranslations();
+      translate('static');
+      translate(\`dynamic.\${foo}\`);
+    }"
+  `);
 });
 
 test('babel-plugin-i18n - invalid usage of useTranslations', () => {

--- a/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
+++ b/fusion-cli/build/babel-plugins/babel-plugin-i18n/test/index.test.js
@@ -1,9 +1,9 @@
 // @flow
-const { transformSync } = require("@babel/core");
+const {transformSync} = require('@babel/core');
 
-const plugin = require("../");
+const plugin = require('../');
 
-test("babel-plugin-i18n", () => {
+test('babel-plugin-i18n', () => {
   const translationIds = new Set();
   const output = transformSync(
     `
@@ -15,9 +15,9 @@ export default function() {
   `,
     {
       parserOpts: {
-        plugins: ["jsx"]
+        plugins: ['jsx'],
       },
-      plugins: [[plugin, { translationIds }]]
+      plugins: [[plugin, {translationIds}]],
     }
   );
   expect(translationIds).toMatchInlineSnapshot(`
@@ -33,7 +33,7 @@ export default function() {
       `);
 });
 
-test("babel-plugin-i18n - invalid usage of <Translate>", () => {
+test('babel-plugin-i18n - invalid usage of <Translate>', () => {
   const translationIds = new Set();
   expect(() =>
     transformSync(
@@ -46,15 +46,15 @@ export default function() {
   `,
       {
         parserOpts: {
-          plugins: ["jsx"]
+          plugins: ['jsx'],
         },
-        plugins: [[plugin, { translationIds }]]
+        plugins: [[plugin, {translationIds}]],
       }
     )
-  ).toThrow("The translate component must have props.id be a string literal.");
+  ).toThrow('The translate component must have props.id be a string literal.');
 });
 
-test("babel-plugin-i18n - valid usage of useTranslations", () => {
+test('babel-plugin-i18n - valid usage of useTranslations', () => {
   const translationIds = new Set();
   const output = transformSync(
     `
@@ -67,7 +67,7 @@ export default function() {
 }
   `,
     {
-      plugins: [[plugin, { translationIds }]]
+      plugins: [[plugin, {translationIds}]],
     }
   );
   expect(translationIds).toMatchInlineSnapshot(`
@@ -89,11 +89,11 @@ export default function() {
     `);
 });
 
-test("babel-plugin-i18n - invalid usage of useTranslations", () => {
+test('babel-plugin-i18n - invalid usage of useTranslations', () => {
   const translationIds = new Set();
   expect(() =>
     transformSync(
-    `
+      `
 import {useTranslations} from 'fusion-plugin-i18n-react'; 
 
 export default function() {
@@ -102,8 +102,10 @@ export default function() {
 }
   `,
       {
-        plugins: [[plugin, { translationIds }]]
+        plugins: [[plugin, {translationIds}]],
       }
     )
-  ).toThrow("useTranslations result function must be passed string literal or hinted template literal");
+  ).toThrow(
+    'useTranslations result function must be passed string literal or hinted template literal'
+  );
 });

--- a/fusion-cli/test/e2e/split-translations/fixture/src/hocTranslation.js
+++ b/fusion-cli/test/e2e/split-translations/fixture/src/hocTranslation.js
@@ -1,0 +1,14 @@
+// @noflow
+
+import React from 'react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
+
+function Component({translate}) {
+  return (
+    <div id="with-translation">
+        {translate('translations.hoc')}
+    </div>
+  );
+}
+
+export default withTranslations(['translations.hoc'])(Component);

--- a/fusion-cli/test/e2e/split-translations/fixture/src/hookTranslation.js
+++ b/fusion-cli/test/e2e/split-translations/fixture/src/hookTranslation.js
@@ -4,15 +4,7 @@ import React from 'react';
 import {useTranslations} from 'fusion-plugin-i18n-react';
 
 export default () => {
-  const translate = useTranslations(['pattern.*', 'translations.hook']);
-  /*
-  useTranslations(['pattern.*', 'translations.hook']);
   const translate = useTranslations();
-  */
-  /*
-  useTranslations(['pattern.*', 'translations.hook']);
-  const {translate} = useService(I18nToken).from(React.useContext(FusionContext));
-  */
   return (
     <div id="hook-translation">
       <p>

--- a/fusion-cli/test/e2e/split-translations/fixture/src/hookTranslation.js
+++ b/fusion-cli/test/e2e/split-translations/fixture/src/hookTranslation.js
@@ -1,0 +1,26 @@
+// @noflow
+
+import React from 'react';
+import {useTranslations} from 'fusion-plugin-i18n-react';
+
+export default () => {
+  const translate = useTranslations(['pattern.*', 'translations.hook']);
+  /*
+  useTranslations(['pattern.*', 'translations.hook']);
+  const translate = useTranslations();
+  */
+  /*
+  useTranslations(['pattern.*', 'translations.hook']);
+  const {translate} = useService(I18nToken).from(React.useContext(FusionContext));
+  */
+  return (
+    <div id="hook-translation">
+      <p>
+        {translate('translations.hook')}
+      </p>
+      <p>
+        {translate(`pattern.${'def'}`)}
+      </p>
+    </div>
+  );
+}

--- a/fusion-cli/test/e2e/split-translations/fixture/src/root.js
+++ b/fusion-cli/test/e2e/split-translations/fixture/src/root.js
@@ -3,6 +3,8 @@
 import React from 'react';
 import Router, {Route, Switch, Link} from 'fusion-plugin-react-router';
 import {Translate} from 'fusion-plugin-i18n-react';
+import HOCTranslations from './hocTranslation.js'; 
+import HookTranslations from './hookTranslation.js';
 
 import routes from './routes';
 
@@ -10,6 +12,8 @@ export default function Root() {
   return (
     <div>
       <Translate id="main" />
+      <HOCTranslations/>
+      <HookTranslations/>
       <Link id="split1-link" to="/split1">
         go to /split1 route
       </Link>

--- a/fusion-cli/test/e2e/split-translations/fixture/translations/en-US.json
+++ b/fusion-cli/test/e2e/split-translations/fixture/translations/en-US.json
@@ -6,6 +6,6 @@
   "unused": "__UNUSED_TRANSLATED__",
   "translations.hoc": "__HOC_TRANSLATED__",
   "translations.hook": "__HOOK_TRANSLATED__",
-  "pattern.abc": "__abc_TRANSLATED__",
-  "pattern.def": "__def_TRANSLATED__"
+  "pattern.abc": "__ABC_TRANSLATED__",
+  "pattern.def": "__DEF_TRANSLATED__"
 }

--- a/fusion-cli/test/e2e/split-translations/fixture/translations/en-US.json
+++ b/fusion-cli/test/e2e/split-translations/fixture/translations/en-US.json
@@ -3,5 +3,9 @@
   "split1": "__SPLIT1_TRANSLATED__",
   "split2": "__SPLIT2_TRANSLATED__",
   "hot": "__HOT_TRANSLATED__",
-  "unused": "__UNUSED_TRANSLATED__"
+  "unused": "__UNUSED_TRANSLATED__",
+  "translations.hoc": "__HOC_TRANSLATED__",
+  "translations.hook": "__HOOK_TRANSLATED__",
+  "pattern.abc": "__abc_TRANSLATED__",
+  "pattern.def": "__def_TRANSLATED__"
 }

--- a/fusion-cli/test/e2e/split-translations/test.js
+++ b/fusion-cli/test/e2e/split-translations/test.js
@@ -30,6 +30,18 @@ test('`fusion build` app with split translations integration', async () => {
     'app content contains translated main chunk'
   );
   t.ok(
+    content.includes('__HOC_TRANSLATED__'),
+    'app content contains translated hoc chunk'
+  );
+  t.ok(
+    content.includes('__HOOK_TRANSLATED__'),
+    'app content contains translated static hook chunk'
+  );
+  t.ok(
+    content.includes('__ABC_TRANSLATED__'),
+    'app content contains translated dynamic hook chunk'
+  );
+  t.ok(
     !content.includes('__SPLIT1_TRANSLATED__'),
     'split translation not inlined'
   );

--- a/fusion-plugin-i18n-react/README.md
+++ b/fusion-plugin-i18n-react/README.md
@@ -16,6 +16,7 @@ For date I18n, consider using [date-fns](https://date-fns.org/).
 * [Usage](#usage)
   * [React component](#react-component)
   * [Higher order component](#higher-order-component)
+  * [React hook](#react-hook)
   * [Examples of translation files](#examples-of-translation-files)
 * [Setup](#setup)
 * [API](#api)
@@ -29,6 +30,7 @@ For date I18n, consider using [date-fns](https://date-fns.org/).
   * [Service API](#service-api)
   * [React component](#react-component-1)
   * [Higher order component](#higher-order-component-1)
+  * [React hook](#react-hook-1)
 * [Other examples](#other-examples)
   * [Custom translations loader example](#custom-translations-loader-example)
 
@@ -46,15 +48,15 @@ yarn add fusion-plugin-i18n-react
 
 #### React component
 
-If you are using React, we recommend using the supplied `Translate` component.
+We recommend using the supplied `Translate` component for static translations.
 
 ```js
 import React from 'react';
-import {Translate, withTranslations} from 'fusion-plugin-i18n-react';
+import {Translate} from 'fusion-plugin-i18n-react';
 
 export default () => {
-  return <Translate id="test" data={{name: 'world'}} />);
-});
+  return <Translate id="test" data={{name: 'world'}} />;
+};
 ```
 
 #### Higher order component
@@ -63,11 +65,25 @@ A higher order component is provided to allow passing translations to third-part
 
 ```js
 import React from 'react';
-import {Translate, withTranslations} from 'fusion-plugin-i18n-react';
+import {withTranslations} from 'fusion-plugin-i18n-react';
 
 export default withTranslations(['test'])(({translate}) => {
   return <input placeholder={translate('test', {name: 'world'})} />;
 });
+```
+
+#### React Hook
+
+The React hook is currently the only way that dynamic translations are supported. `useTranslations` returns a function that can be used to dynamically translate a template string. Be aware that fusion-cli with throw an error if you attempt to pass a variable or a template string that is not hinted (i.e. has some unchanging parts). Try to use dynamic translations only when completely necessary because all translations that match this dynamic template string will be transferred to the client, contributing to an increase in overall application size.
+
+```js
+import React from 'react';
+import {useTranslations} from 'fusion-plugin-i18n-react';
+
+export default (props) => {
+  const translate = useTranslations();
+  return <span>translate(`cities.${props.city}`)</span>;
+};
 ```
 
 #### Examples of translation files
@@ -274,6 +290,38 @@ type WithTranslations = (
 * `translationKeys: Array<string>` - list of keys with which to provide translations for.
 * `translate: (key: string, interpolations: Object) => string` - returns the translation for the given key, with the provided interpolations.
 * `localeCode: string = 'en_US'` - the current `localeCode` we are tranlating to. Defaults to `en_US`.
+
+#### React hook
+
+The React hook is currently the only way that dynamic translations are supported. `useTranslations` returns a function that can be used to dynamically translate a template string. Be aware that fusion-cli with throw an error if you attempt to pass a variable or a template string that is not hinted (i.e. has some unchanging parts). Try to use dynamic translations only when completely necessary because all translations that match this dynamic template string will be transferred to the client, contributing to an increase in overall application size.
+
+Given this usage of `useTranslations`:
+
+```js
+import {useTranslations} from 'fusion-plugin-i18n-react';
+
+export default () => {
+  const translate = useTranslations();
+  translate(`static.${dynamicValue}`);
+};
+```
+
+And given this translations json file:
+
+```json
+{
+  "static.foo": "foo",
+  "static.bar": "bar",
+  "static.baz": "baz"
+}
+```
+
+All 3 translations will be loaded on the client.
+
+The `translate` function returned from `useTranslations` has the same signature as the [service api](#service-api).
+
+* `key: string` - Required. May be a *hinted* template string or a hard-coded string literal. This plugin uses a babel transform to perform static analysis on this value.
+* `interpolations: Object` - Optional. Replaces `${value}` interpolation placeholders in a translation string with the property of the specified name.
 
 ---
 

--- a/fusion-plugin-i18n-react/src/__tests__/__snapshots__/use-translations.test.browser.js.snap
+++ b/fusion-plugin-i18n-react/src/__tests__/__snapshots__/use-translations.test.browser.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useTranslations() hook 1`] = `"<div>foo bar baz</div>"`;

--- a/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
@@ -8,15 +8,15 @@ import {I18nContext} from '../plugin.js';
 
 test('useTranslations() hook', () => {
   function Foo() {
-    const translate = useTranslations('foo');
-    return <div>{translate()}</div>;
+    const translate = useTranslations();
+    return <div>{translate('foo')}</div>;
   }
 
   const mockI18n = {
     async load() {},
     localeCode: 'fr_CA',
-    translate() {
-      return 'foo bar baz';
+    translate(str) {
+      return `${str} bar baz`;
     },
   };
 

--- a/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import {useTranslations} from '../index';
+import {I18nContext} from '../plugin.js';
+
+test('useTranslations() hook', () => {
+  function Foo() {
+    const translate = useTranslations('foo');
+    return (
+      <div>
+        {translate()}
+      </div>
+    );
+  }
+
+  const mockI18n = {
+    async load() {},
+    localeCode: 'fr_CA',
+    translate() {
+      return 'foo bar baz';
+    },
+  };
+
+  expect(
+    mount(
+      <I18nContext.Provider value={mockI18n}>
+        <Foo />
+      </I18nContext.Provider>
+    ).html()
+  ).toMatchSnapshot();
+});

--- a/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
+++ b/fusion-plugin-i18n-react/src/__tests__/use-translations.test.browser.js
@@ -9,11 +9,7 @@ import {I18nContext} from '../plugin.js';
 test('useTranslations() hook', () => {
   function Foo() {
     const translate = useTranslations('foo');
-    return (
-      <div>
-        {translate()}
-      </div>
-    );
+    return <div>{translate()}</div>;
   }
 
   const mockI18n = {

--- a/fusion-plugin-i18n-react/src/index.js
+++ b/fusion-plugin-i18n-react/src/index.js
@@ -22,6 +22,7 @@ export type {
 } from 'fusion-plugin-i18n';
 
 export {withTranslations} from './with-translations';
+export {useTranslations} from './use-translations';
 export {Translate} from './translate';
 
 export default I18n;

--- a/fusion-plugin-i18n-react/src/use-translations.js
+++ b/fusion-plugin-i18n-react/src/use-translations.js
@@ -1,0 +1,17 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {useContext} from 'react';
+import {I18nContext} from './plugin.js';
+
+export function useTranslations(patterns) { // eslint-disable-line
+  // patterns is statically analyzed and not used here
+  const i18n = useContext(I18nContext);
+
+  return i18n.translate.bind(i18n);
+}

--- a/fusion-plugin-i18n-react/src/use-translations.js
+++ b/fusion-plugin-i18n-react/src/use-translations.js
@@ -9,8 +9,7 @@
 import {useContext} from 'react';
 import {I18nContext} from './plugin.js';
 
-export function useTranslations(patterns) { // eslint-disable-line
-  // patterns is statically analyzed and not used here
+export function useTranslations() {
   const i18n = useContext(I18nContext);
 
   return i18n.translate.bind(i18n);

--- a/fusion-plugin-i18n/src/__tests__/index.browser.js
+++ b/fusion-plugin-i18n/src/__tests__/index.browser.js
@@ -124,7 +124,7 @@ test('load', t => {
   };
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   const fetch: any = (url, options) => {
-    t.equals(url, '/_translations?keys=test-key', 'url is ok');
+    t.equals(url, '/_translations?keys=["test-key"]', 'url is ok');
     t.equals(options && options.method, 'POST', 'method is ok');
     t.equals(
       options && options.headers && options.headers['X-Fusion-Locale-Code'],

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -181,6 +181,8 @@ test('matchesLiteralSections matches positionally', async t => {
     'animals.Buffalo',
     'animals.Cat',
     'test',
+    'testend',
+    'starttest',
   ];
 
   // handles ending matches

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -176,7 +176,7 @@ test('matchesOrder matches positionally', async t => {
     'cities.LosAngeles',
     'animals.Buffalo',
     'animals.Cat',
-    'test'
+    'test',
   ];
 
   // translate(`${}.Buffalo`);
@@ -206,21 +206,29 @@ test('matchesOrder matches positionally', async t => {
 
   // translate(`${}citi${}s.${}a${}o`);
   // handles multiple parts
-  const matches1 = translations.filter(matchesOrder(['', 'citi', 's.', 'a', 'o']));
+  const matches1 = translations.filter(
+    matchesOrder(['', 'citi', 's.', 'a', 'o'])
+  );
   t.deepEqual(matches1, ['cities.Buffalo', 'cities.Chicago']);
 
   // translate(`${}citi${}s.${}A${}o`);
   // confines match to later parts in the string
-  const matches2 = translations.filter(matchesOrder(['', 'citi', 's.', 'A', 'o']));
+  const matches2 = translations.filter(
+    matchesOrder(['', 'citi', 's.', 'A', 'o'])
+  );
   t.deepEqual(matches2, []);
 
   // translate(`${}citi${}s.${}A${}`);
-  const matches3 = translations.filter(matchesOrder(['', 'citi', 's.', 'A', '']));
+  const matches3 = translations.filter(
+    matchesOrder(['', 'citi', 's.', 'A', ''])
+  );
   t.deepEqual(matches3, ['cities.LosAngeles']);
 
   // translate(`${}ab${}bc${}`);
   // doesn't overlap matches
-  const matches4 = ['abc', 'abbc', 'ababc'].filter(matchesOrder(['', 'ab', 'bc', '']));
+  const matches4 = ['abc', 'abbc', 'ababc'].filter(
+    matchesOrder(['', 'ab', 'bc', ''])
+  );
   t.deepEqual(matches4, ['abbc', 'ababc']);
 
   t.end();

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -170,6 +170,10 @@ test('non matched route', async t => {
 });
 
 test('matchesOrder matches positionally', async t => {
+  function literalSections(quasis) {
+    return quasis;
+  }
+
   const translations = [
     'cities.Buffalo',
     'cities.Chicago',
@@ -179,18 +183,21 @@ test('matchesOrder matches positionally', async t => {
     'test',
   ];
 
-  // translate(`${}.Buffalo`);
   // handles ending matches
-  const buffaloMatches = translations.filter(matchesOrder(['', '.Buffalo']));
+  const buffaloMatches = translations.filter(
+    matchesOrder(literalSections`${''}.Buffalo`)
+  );
   t.deepEqual(buffaloMatches, ['cities.Buffalo', 'animals.Buffalo']);
 
-  // translate(`animals.${}`);
   // handles beginning matches'
-  const animalMatches = translations.filter(matchesOrder(['animals.', '']));
+  const animalMatches = translations.filter(
+    matchesOrder(literalSections`animals.${''}`)
+  );
   t.deepEqual(animalMatches, ['animals.Buffalo', 'animals.Cat']);
 
-  // translate(`${}.${}`);
-  const dotMatches = translations.filter(matchesOrder(['', '.', '']));
+  const dotMatches = translations.filter(
+    matchesOrder(literalSections`${''}.${''}`)
+  );
   t.deepEqual(dotMatches, [
     'cities.Buffalo',
     'cities.Chicago',
@@ -199,35 +206,32 @@ test('matchesOrder matches positionally', async t => {
     'animals.Cat',
   ]);
 
-  // translate('test');
   // handles static matches
-  const staticMatches = translations.filter(matchesOrder(['test']));
+  const staticMatches = translations.filter(
+    matchesOrder(literalSections`test`)
+  );
   t.deepEqual(staticMatches, ['test']);
 
-  // translate(`${}citi${}s.${}a${}o`);
   // handles multiple parts
   const matches1 = translations.filter(
-    matchesOrder(['', 'citi', 's.', 'a', 'o'])
+    matchesOrder(literalSections`${''}citi${''}s.${''}a${''}o`)
   );
   t.deepEqual(matches1, ['cities.Buffalo', 'cities.Chicago']);
 
-  // translate(`${}citi${}s.${}A${}o`);
   // confines match to later parts in the string
   const matches2 = translations.filter(
-    matchesOrder(['', 'citi', 's.', 'A', 'o'])
+    matchesOrder(literalSections`${''}citi${''}s.${''}A${''}o`)
   );
   t.deepEqual(matches2, []);
 
-  // translate(`${}citi${}s.${}A${}`);
   const matches3 = translations.filter(
-    matchesOrder(['', 'citi', 's.', 'A', ''])
+    matchesOrder(literalSections`${''}citi${''}s.${''}A${''}`)
   );
   t.deepEqual(matches3, ['cities.LosAngeles']);
 
-  // translate(`${}ab${}bc${}`);
   // doesn't overlap matches
   const matches4 = ['abc', 'abbc', 'ababc'].filter(
-    matchesOrder(['', 'ab', 'bc', ''])
+    matchesOrder(literalSections`${''}ab${''}bc${''}`)
   );
   t.deepEqual(matches4, ['abbc', 'ababc']);
 

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -14,7 +14,7 @@ import {getSimulator} from 'fusion-test-utils';
 import App, {consumeSanitizedHTML} from 'fusion-core';
 import type {Context} from 'fusion-core';
 
-import I18n, {matchesOrder} from '../node';
+import I18n, {matchesLiteralSections} from '../node';
 import {I18nLoaderToken} from '../tokens.js';
 import {I18nToken} from '../index';
 
@@ -169,7 +169,7 @@ test('non matched route', async t => {
   t.end();
 });
 
-test('matchesOrder matches positionally', async t => {
+test('matchesLiteralSections matches positionally', async t => {
   function literalSections(quasis, ...substitutions) {
     return quasis;
   }
@@ -185,18 +185,18 @@ test('matchesOrder matches positionally', async t => {
 
   // handles ending matches
   const buffaloMatches = translations.filter(
-    matchesOrder(literalSections`${''}.Buffalo`)
+    matchesLiteralSections(literalSections`${''}.Buffalo`)
   );
   t.deepEqual(buffaloMatches, ['cities.Buffalo', 'animals.Buffalo']);
 
   // handles beginning matches'
   const animalMatches = translations.filter(
-    matchesOrder(literalSections`animals.${''}`)
+    matchesLiteralSections(literalSections`animals.${''}`)
   );
   t.deepEqual(animalMatches, ['animals.Buffalo', 'animals.Cat']);
 
   const dotMatches = translations.filter(
-    matchesOrder(literalSections`${''}.${''}`)
+    matchesLiteralSections(literalSections`${''}.${''}`)
   );
   t.deepEqual(dotMatches, [
     'cities.Buffalo',
@@ -208,30 +208,30 @@ test('matchesOrder matches positionally', async t => {
 
   // handles static matches
   const staticMatches = translations.filter(
-    matchesOrder(literalSections`test`)
+    matchesLiteralSections(literalSections`test`)
   );
   t.deepEqual(staticMatches, ['test']);
 
   // handles multiple parts
   const matches1 = translations.filter(
-    matchesOrder(literalSections`${''}citi${''}s.${''}a${''}o`)
+    matchesLiteralSections(literalSections`${''}citi${''}s.${''}a${''}o`)
   );
   t.deepEqual(matches1, ['cities.Buffalo', 'cities.Chicago']);
 
   // confines match to later parts in the string
   const matches2 = translations.filter(
-    matchesOrder(literalSections`${''}citi${''}s.${''}A${''}o`)
+    matchesLiteralSections(literalSections`${''}citi${''}s.${''}A${''}o`)
   );
   t.deepEqual(matches2, []);
 
   const matches3 = translations.filter(
-    matchesOrder(literalSections`${''}citi${''}s.${''}A${''}`)
+    matchesLiteralSections(literalSections`${''}citi${''}s.${''}A${''}`)
   );
   t.deepEqual(matches3, ['cities.LosAngeles']);
 
   // doesn't overlap matches
   const matches4 = ['abc', 'abbc', 'ababc'].filter(
-    matchesOrder(literalSections`${''}ab${''}bc${''}`)
+    matchesLiteralSections(literalSections`${''}ab${''}bc${''}`)
   );
   t.deepEqual(matches4, ['abbc', 'ababc']);
 

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -170,7 +170,7 @@ test('non matched route', async t => {
 });
 
 test('matchesOrder matches positionally', async t => {
-  function literalSections(quasis) {
+  function literalSections(quasis, ...substitutions) {
     return quasis;
   }
 

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -112,7 +112,7 @@ test('endpoint', async t => {
     preloadChunks: [],
     headers: {'accept-language': 'en_US'},
     path: '/_translations',
-    querystring: 'keys=test,interpolated',
+    querystring: 'keys=["test","interpolated"]',
     memoized: new Map(),
     body: '',
   };

--- a/fusion-plugin-i18n/src/browser.js
+++ b/fusion-plugin-i18n/src/browser.js
@@ -87,7 +87,10 @@ const pluginFactory: () => PluginType = () =>
               this.requestedKeys.add(key);
             });
             // TODO(#3) don't append prefix if injected fetch also injects prefix
-            return fetch(`/_translations?keys=${JSON.stringify(unloaded)}`, fetchOpts)
+            return fetch(
+              `/_translations?keys=${JSON.stringify(unloaded)}`,
+              fetchOpts
+            )
               .then(r => r.json())
               .then((data: {[string]: string}) => {
                 for (const key in data) {

--- a/fusion-plugin-i18n/src/browser.js
+++ b/fusion-plugin-i18n/src/browser.js
@@ -86,9 +86,8 @@ const pluginFactory: () => PluginType = () =>
             unloaded.forEach(key => {
               this.requestedKeys.add(key);
             });
-            const keys = unloaded.join(',');
             // TODO(#3) don't append prefix if injected fetch also injects prefix
-            return fetch(`/_translations?keys=${keys}`, fetchOpts)
+            return fetch(`/_translations?keys=${JSON.stringify(unloaded)}`, fetchOpts)
               .then(r => r.json())
               .then((data: {[string]: string}) => {
                 for (const key in data) {

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -96,7 +96,9 @@ const pluginFactory: () => PluginType = () =>
             ...ctx.preloadChunks,
           ];
           const translations = {};
-          const possibleTranslations = i18n.translations ? Object.keys(i18n.translations) : [];
+          const possibleTranslations = i18n.translations
+            ? Object.keys(i18n.translations)
+            : [];
           chunks.forEach(id => {
             const keys = Array.from(
               chunkTranslationMap.translationsForChunk(id)
@@ -105,7 +107,8 @@ const pluginFactory: () => PluginType = () =>
               if (Array.isArray(key)) {
                 const matches = possibleTranslations.filter(matchesOrder(key));
                 for (const match of matches) {
-                  translations[match] = i18n.translations && i18n.translations[match];
+                  translations[match] =
+                    i18n.translations && i18n.translations[match];
                 }
               } else {
                 translations[key] = i18n.translations && i18n.translations[key];
@@ -134,7 +137,9 @@ const pluginFactory: () => PluginType = () =>
           const keys = JSON.parse(
             querystring.parse(ctx.querystring).keys || '[]'
           );
-          const possibleTranslations = i18n.translations ? Object.keys(i18n.translations) : [];
+          const possibleTranslations = i18n.translations
+            ? Object.keys(i18n.translations)
+            : [];
           const translations = keys.reduce((acc, key) => {
             if (Array.isArray(key)) {
               const matches = possibleTranslations.filter(matchesOrder(key));

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -36,10 +36,12 @@ export function matchesOrder(key) {
         return true;
       } else if (i === key.length - 1 && translation.endsWith(part)) {
         return true;
-      } else if (translation.indexOf(part, matchIndex) !== -1) {
+      } else {
         const offset = translation.indexOf(part, matchIndex);
-        matchIndex = offset + part.length;
-        return true;
+        if (offset !== -1) {
+          matchIndex = offset + part.length;
+          return true;
+        }
       }
       // a part failed
       return false;

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -22,7 +22,8 @@ import type {
   TranslationsObjectType,
 } from './types.js';
 
-function matchesOrder(key) {
+// exported for testing
+export function matchesOrder(key) {
   return translation => {
     let matchIndex = 0;
 
@@ -36,7 +37,8 @@ function matchesOrder(key) {
       } else if (i === key.length - 1 && translation.endsWith(part)) {
         return true;
       } else if (translation.indexOf(part, matchIndex) !== -1) {
-        matchIndex += part;
+        const offset = translation.indexOf(part, matchIndex);
+        matchIndex = offset + part.length;
         return true;
       }
       // a part failed

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -27,6 +27,11 @@ export function matchesLiteralSections(literalSections: Array<string>) {
   return (translation: string) => {
     let lastMatchIndex = 0;
 
+    if (literalSections.length === 1) {
+      const literal = literalSections[0];
+      return literal !== '' && translation === literal;
+    }
+
     return literalSections.every((literal, literalIndex) => {
       if (literal === '') {
         // literal section either:

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -23,8 +23,8 @@ import type {
 } from './types.js';
 
 // exported for testing
-export function matchesOrder(key) {
-  return translation => {
+export function matchesOrder(key: Array<string>) {
+  return (translation: string) => {
     let matchIndex = 0;
 
     return key.every((part, i) => {


### PR DESCRIPTION
Implemented based on this conversation https://github.com/fusionjs/fusionjs/issues/340

Closes #345
Closes #340

The `useTranslations` hook supports dynamic translations when given a hinted template string.

```js
const translate = useTranslations();

// 👍 works
translate('static')
translate(`static.${dynamic}`)
translate(`${dynamic}${dynamic}${dynamic}.static`)

// 👎 fails
translate(foo)
translate(`${foo}`)
translate(`${dynamic}${dynamic}${dynamic}`)
translate('static' + 'also-static')
translate(42)
```

The translation key extracted from `translate` is an array of strings. Using this array, we can match each item (in order) to the loaded translations. This prevents us from coming up with some dynamic regex or DSL pattern representation.