### PR TITLE
Fix inconsistency between Flow and Prettier

### DIFF
--- a/eslint-config-fusion/index.js
+++ b/eslint-config-fusion/index.js
@@ -33,13 +33,7 @@ module.exports = {
 
     // Fix inconsistency between Flow (inherited rule from flowtype/recommended) and Prettier
     // https://jeng.uberinternal.com/browse/WPT-3404
-    'flowtype/space-after-type-colon': [
-      2,
-      'always',
-      {
-        allowLineBreak: true,
-      },
-    ],
+    'flowtype/space-after-type-colon': 'off',
   },
   settings: {
     react: {

--- a/eslint-config-fusion/index.js
+++ b/eslint-config-fusion/index.js
@@ -30,6 +30,16 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     // https://github.com/facebook/react/issues/14920
     'react-hooks/exhaustive-deps': 'warn',
+
+    // Fix inconsistency between Flow (inherited rule from flowtype/recommended) and Prettier
+    // https://jeng.uberinternal.com/browse/WPT-3404
+    'flowtype/space-after-type-colon': [
+      2,
+      'always',
+      {
+        allowLineBreak: true,
+      },
+    ],
   },
   settings: {
     react: {


### PR DESCRIPTION
Resolves [WPT-3404](https://jeng.uberinternal.com/browse/WPT-3404):

> **Impetus**
> 
> It appears that the default lint rules for Fusion.js may cause an inconsistent state when typing multi-line Flow types.
> 
> **Reproduction steps**
> 
> An example is below:
> 
> ```js
> export type TestType = {
>   someProp:
>     | Array<number | string | {} | void | (() => void)>
>     | number
>     | string
>     | {}
>     | void
>     | (() => void),
> };
> ```
> 
> In the above case, ESlint will throw the following complaint:
> 
> > There must not be a line break after "someProp" type annotation colon.eslint(flowtype/space-after-type-colon)
> 
> The autogenerated fix for this results in:
> ```js
> export type TestType = {
>   someProp: | Array<number | string | {} | void | (() => void)>
>     | number
>     | string
>     | {}
>     | void
>     | (() => void),
> };
> ```
> 
> Which prettier complains about:
> 
> > Insert `⏎- - - `eslint(prettier/prettier)
> 
> These two ping pong back and forth.