### PR TITLE
Add support for bazel

### DIFF
--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -646,7 +646,9 @@ function getNodeConfig(runtime) {
 function getSrcPath(dir) {
   // resolving to the real path of a known top-level file is required to support Bazel, which symlinks source files individually
   try {
-    const real = path.dirname(fs.realpathSync(path.resolve(dir, 'package.json')));
+    const real = path.dirname(
+      fs.realpathSync(path.resolve(dir, 'package.json'))
+    );
     return path.resolve(real, 'src');
   } catch (e) {
     return path.resolve(dir, 'src');

--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -168,7 +168,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
 
   const getTransformDefault = modulePath => {
     if (
-      modulePath.startsWith(path.join(dir, 'src')) ||
+      modulePath.startsWith(getSrcPath(dir)) ||
       /fusion-cli(\/|\\)(entries|plugins)/.test(modulePath)
     ) {
       return 'all';
@@ -641,4 +641,10 @@ function getNodeConfig(runtime) {
     repl: emptyForWeb,
     tls: emptyForWeb,
   };
+}
+
+function getSrcPath(dir) {
+  // resolving to the real path of a known top-level file is required to support Bazel, which symlinks source files individually
+  const real = path.dirname(fs.realpathSync(path.resolve(dir, 'package.json')));
+  return path.resolve(dir, 'src');
 }

--- a/fusion-cli/build/get-webpack-config.js
+++ b/fusion-cli/build/get-webpack-config.js
@@ -645,6 +645,10 @@ function getNodeConfig(runtime) {
 
 function getSrcPath(dir) {
   // resolving to the real path of a known top-level file is required to support Bazel, which symlinks source files individually
-  const real = path.dirname(fs.realpathSync(path.resolve(dir, 'package.json')));
-  return path.resolve(dir, 'src');
+  try {
+    const real = path.dirname(fs.realpathSync(path.resolve(dir, 'package.json')));
+    return path.resolve(real, 'src');
+  } catch (e) {
+    return path.resolve(dir, 'src');
+  }
 }


### PR DESCRIPTION
Bazel creates a copy of the project folder structure, but symlinks each file to their real paths. This breaks the Babel loader.

This PR resolves include paths to look at realpath to make Babel work inside Bazel sandboxes