### PR TITLE
Fix string interpolation in README

### DIFF
--- a/fusion-plugin-rpc-redux-react/README.md
+++ b/fusion-plugin-rpc-redux-react/README.md
@@ -41,7 +41,7 @@ yarn add fusion-plugin-rpc-redux-react
 // src/rpc/index.js
 export default {
   greet: async ({name}, ctx) => {
-    return {greeting: 'hello ${name}'}
+    return {greeting: `hello ${name}`}
   }
 }
 


### PR DESCRIPTION
Super minor but I was going through this guide and copy/pasting and noticed that the string interpolation was incorrect.