### PR TITLE
Add koa-bodyparser flow types, fix error [fusion-plugin-rpc]

### DIFF
--- a/fusion-plugin-rpc/flow-typed/koa-bodyparser_v4.x.x.js
+++ b/fusion-plugin-rpc/flow-typed/koa-bodyparser_v4.x.x.js
@@ -1,0 +1,29 @@
+// @flow
+// flow-typed signature: db2ab32952e719c6656cef681be04c96
+// flow-typed version: e969a7af52/koa-bodyparser_v4.x.x/flow_>=v0.56.x
+
+declare module 'koa-bodyparser' {
+  declare type Context = Object;
+
+  declare type Middleware = (
+    ctx: Context,
+    next: () => Promise<void>
+  ) => Promise<void> | void;
+
+  declare type Options = {|
+    enableTypes?: Array<string>,
+    encode?: string,
+    formLimit?: string,
+    jsonLimit?: string,
+    strict?: boolean,
+    detectJSON?: (ctx: Context) => boolean,
+    extendTypes?: {
+      json?: Array<string>,
+      form?: Array<string>,
+      text?: Array<string>,
+    },
+    onerror?: (err: Error, ctx: Context) => void,
+  |};
+
+  declare module.exports: (opts?: Options) => Middleware;
+}

--- a/fusion-plugin-rpc/src/tokens.js
+++ b/fusion-plugin-rpc/src/tokens.js
@@ -8,6 +8,7 @@
 
 import {createToken} from 'fusion-core';
 import type {Token} from 'fusion-core';
+import type {Options} from 'koa-bodyparser';
 import type {RPCConfigType} from './types';
 
 export const RPCToken: Token<any> = createToken('RPCToken');
@@ -16,7 +17,7 @@ export type HandlerType = {[string]: (...args: any) => any};
 export const RPCHandlersToken: Token<HandlerType> = createToken(
   'RPCHandlersToken'
 );
-export const BodyParserOptionsToken: Token<mixed> = createToken(
+export const BodyParserOptionsToken: Token<Options> = createToken(
   'BodyParserOptionsToken'
 );
 export const RPCHandlersConfigToken: Token<RPCConfigType> = createToken(


### PR DESCRIPTION
I'm working in a fusion app that has koa-bodyparser flow types, and I'm getting an error when registering the plugin from `fusion-plugin-rpc`:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/fusion-plugin-rpc/src/server.js:122:36

Cannot call bodyparser with bodyParserOptions bound to opts because inexact mixed [1] is incompatible with exact
Options [2].

     node_modules/fusion-plugin-rpc/src/server.js
     119│         throw new Error('Missing handlers registered to RPCHandlersToken');
     120│       if (!emitter)
     121│         throw new Error('Missing emitter registered to UniversalEventsToken');
     122│       const parseBody = bodyparser(bodyParserOptions);
     123│
     124│       return async (ctx, next) => {
     125│         await next();

     flow-typed/npm/koa-bodyparser_v4.x.x.js
 [2]  27│   declare module.exports: (opts?: Options) => Middleware;

     node_modules/fusion-plugin-rpc/src/tokens.js
 [1]  18│ export const BodyParserOptionsToken: Token<mixed> = createToken(
```

This PR adds the koa-bodyparser flow types using flow-typed, and fixes the flow error that results from using `mixed` instead of `Options` in the type used for the `BodyParserOptionsToken`.

I got around this in my application by removing the flow-typed file, but wanted to open a PR to report the issue I had as well as suggest an option to fix it.