### PR TITLE
Enable configurable jest transformIgnorePatterns

### DIFF
--- a/fusion-cli/build/jest/base-jest-config.js
+++ b/fusion-cli/build/jest/base-jest-config.js
@@ -36,6 +36,20 @@ function getReactSetup() {
 
 const reactSetup = getReactSetup();
 
+function getTransformIgnorePatterns() {
+  const defaults = ['/node_modules/(?!(fusion-cli.*build))'];
+  try {
+    const path = require('path');
+    // $FlowFixMe
+    const fusionrc = require(path.resolve(process.cwd(), '.fusionrc.js'));
+    return fusionrc.jest.transformIgnorePatterns;
+  } catch (e) {
+    return defaults;
+  }
+}
+
+const transformIgnorePatterns = getTransformIgnorePatterns();
+
 module.exports = {
   coverageDirectory: `${process.cwd()}/coverage`,
   coverageReporters: ['json'],
@@ -44,7 +58,7 @@ module.exports = {
     '\\.js$': require.resolve('./jest-transformer.js'),
     '\\.(gql|graphql)$': require.resolve('./graphql-jest-transformer.js'),
   },
-  transformIgnorePatterns: ['/node_modules/(?!(fusion-cli.*build))'],
+  transformIgnorePatterns,
   setupFiles: [require.resolve('./jest-framework-shims.js'), ...reactSetup],
   snapshotSerializers:
     reactSetup.length > 0 ? [require.resolve('enzyme-to-json/serializer')] : [],

--- a/fusion-cli/build/load-fusionrc.js
+++ b/fusion-cli/build/load-fusionrc.js
@@ -26,6 +26,7 @@ export type FusionRC = {
   experimentalTransformTest?: (modulePath: string, defaults: TransformResult) => TransformResult,
   experimentalBundleTest?: (modulePath: string, defaults: BundleResult) => BundleResult,
   nodeBuiltins?: {[string]: any},
+  jest?: {transformIgnorePatterns?: Array<string>}
 };
 */
 
@@ -69,6 +70,7 @@ function isValid(config) {
         'experimentalTransformTest',
         'experimentalBundleTest',
         'nodeBuiltins',
+        'jest',
       ].includes(key)
     )
   ) {


### PR DESCRIPTION
allows users to white-list node modules for jest-babel transformation