### PR TITLE
Fix client url in context [fusion-core]

### DIFF
--- a/fusion-core/src/client-app.js
+++ b/fusion-core/src/client-app.js
@@ -30,7 +30,7 @@ export default function(): typeof BaseApp {
       return () => {
         // TODO(#62): Create noop context object to match server api
         const ctx: any = {
-          url: window.location.path + window.location.search,
+          url: window.location.pathname + window.location.search,
           element: null,
           body: null,
         };


### PR DESCRIPTION
Must have been a typo. This doesn't seem to be used anywhere, but was the string `"undefined"` since a `undefined` and a string were being concatenated.