### PR TITLE
Fix split component in simulation tests

### DIFF
--- a/fusion-react/src/async/split.js
+++ b/fusion-react/src/async/split.js
@@ -57,7 +57,10 @@ export default function withAsyncComponent<Config>({
       // $FlowFixMe
       let id = promise.__MODULE_ID;
 
-      if (typeof __webpack_modules__ !== "undefined" && __webpack_modules__[id]) {
+      if (
+        typeof __webpack_modules__ !== 'undefined' &&
+        __webpack_modules__[id]
+      ) {
         // If module is already loaded, it can be synchronously imported
         AsyncComponent = __webpack_require__(id).default;
       }

--- a/fusion-react/src/async/split.js
+++ b/fusion-react/src/async/split.js
@@ -57,7 +57,7 @@ export default function withAsyncComponent<Config>({
       // $FlowFixMe
       let id = promise.__MODULE_ID;
 
-      if (__webpack_modules__[id]) {
+      if (typeof __webpack_modules__ !== "undefined" && __webpack_modules__[id]) {
         // If module is already loaded, it can be synchronously imported
         AsyncComponent = __webpack_require__(id).default;
       }


### PR DESCRIPTION
We cannot assume `__webpack_modules__` is defined (i.e. Jest simulation tests that aren't bundled via Webpack)