### PR TITLE
Revert InstrumentedPromise type of fusion-react#split argument

### DIFF
--- a/fusion-react/src/async/split.js
+++ b/fusion-react/src/async/split.js
@@ -83,7 +83,7 @@ export default function withAsyncComponent<Config>({
       }
 
       // $FlowFixMe
-      metadata.chunkIds = componentPromise.__CHUNKS_IDS || [];
+      metadata.chunkIds = componentPromise.__CHUNK_IDS || [];
       // $FlowFixMe
       metadata.i18nKeys = componentPromise.__I18N_KEYS || [];
 

--- a/fusion-react/src/async/split.js
+++ b/fusion-react/src/async/split.js
@@ -10,19 +10,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import prepared from './prepared.js';
 
-export type InstrumentedPromise<T> = Promise<{
-  default: React.ComponentType<T>,
-}> & {
-  __MODULE_ID: string,
-  __CHUNK_IDS: Array<string>,
-  __I18N_KEYS: Array<string>,
-};
-
 declare var __webpack_modules__: {[string]: any};
 declare var __webpack_require__: any => any;
-
-const CHUNKS_KEY = '__CHUNK_IDS';
-const I18N_KEY = '__I18N_KEYS';
 
 const contextTypes = {
   splitComponentLoaders: PropTypes.array.isRequired,
@@ -40,7 +29,7 @@ export default function withAsyncComponent<Config>({
   ErrorComponent,
 }: {
   defer?: boolean,
-  load: () => InstrumentedPromise<Config>,
+  load: () => Promise<{default: React.ComponentType<Config>}>,
   LoadingComponent: React.ComponentType<any>,
   ErrorComponent: React.ComponentType<any>,
 }): React.ComponentType<Config> {
@@ -93,8 +82,10 @@ export default function withAsyncComponent<Config>({
         componentPromise = (Promise.reject(e): any);
       }
 
-      metadata.chunkIds = componentPromise[CHUNKS_KEY] || [];
-      metadata.i18nKeys = componentPromise[I18N_KEY] || [];
+      // $FlowFixMe
+      metadata.chunkIds = componentPromise.__CHUNKS_IDS || [];
+      // $FlowFixMe
+      metadata.i18nKeys = componentPromise.__I18N_KEYS || [];
 
       if (__NODE__ && context.markAsCritical) {
         metadata.chunkIds.forEach(chunkId => {


### PR DESCRIPTION
This was implemented in https://github.com/fusionjs/fusionjs/pull/446

That PR added a type to an argument on an exported API. This would have forced users to import and use the `InstrumentedPromise` type when this is actually an implementation detail that they shouldn't be aware of. Users are only aware that this is a promise, not of the added instrumentation.