### PR TITLE
Add back relevant libdefs

### DIFF
--- a/fusion-core/flow-typed/globals.js
+++ b/fusion-core/flow-typed/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/fusion-core/flow-typed/npm/koa_v2.x.x.js
+++ b/fusion-core/flow-typed/npm/koa_v2.x.x.js
@@ -33,7 +33,7 @@ declare module 'koa' {
     url: string,
     header: SimpleHeader,
   };
-  declare type RequestInspect = void |  RequestJSON;
+  declare type RequestInspect = void | RequestJSON;
   declare type Request = {
     app: Application,
     req: http$IncomingMessage<>,
@@ -65,13 +65,13 @@ declare module 'koa' {
     type: string,
     url: string,
 
-    charset: string  | void,
-    length: number |  void,
+    charset: string | void,
+    length: number | void,
 
     //  Those functions comes from https://github.com/jshttp/accepts/blob/master/index.js
     //  request.js$L445
     //  https://github.com/jshttp/accepts/blob/master/test/type.js
-    accepts: ((args: string[]) => string  | false)  &
+    accepts: ((args: string[]) => string | false) &
       // ToDo: There is an issue https://github.com/facebook/flow/issues/3009
       // if you meet some error here, temporarily add an additional annotation
       // like: `request.accepts((['json', 'text']:Array<string>))` to fix it.
@@ -80,7 +80,7 @@ declare module 'koa' {
 
     //  https://github.com/jshttp/accepts/blob/master/index.js#L153
     //  https://github.com/jshttp/accepts/blob/master/test/charset.js
-    acceptsCharsets: ((args: string[]) => buffer$Encoding | false)  &
+    acceptsCharsets: ((args: string[]) => buffer$Encoding | false) &
       // ToDo: https://github.com/facebook/flow/issues/3009
       // if you meet some error here, see L70.
       ((arg: string, ...args: string[]) => buffer$Encoding | false) &
@@ -88,7 +88,7 @@ declare module 'koa' {
 
     //  https://github.com/jshttp/accepts/blob/master/index.js#L119
     //  https://github.com/jshttp/accepts/blob/master/test/encoding.js
-    acceptsEncodings: ((args: string[]) => string | false)  &
+    acceptsEncodings: ((args: string[]) => string | false) &
       // ToDo: https://github.com/facebook/flow/issues/3009
       // if you meet some error here, see L70.
       ((arg: string, ...args: string[]) => string | false) &
@@ -96,7 +96,7 @@ declare module 'koa' {
 
     //  https://github.com/jshttp/accepts/blob/master/index.js#L185
     //  https://github.com/jshttp/accepts/blob/master/test/language.js
-    acceptsLanguages: ((args: string[]) => string |  false) &
+    acceptsLanguages: ((args: string[]) => string | false) &
       // ToDo: https://github.com/facebook/flow/issues/3009
       // if you meet some error here, see L70.
       ((arg: string, ...args: string[]) => string | false) &
@@ -111,7 +111,7 @@ declare module 'koa' {
      * If there is no content type, `false` is returned.
      * Otherwise, it returns the first `type` that matches.
      */
-    is: ((args: string[]) => null | false | string)  &
+    is: ((args: string[]) => null | false | string) &
       ((arg: string, ...args: string[]) => null | false | string) &
       (() => string), // should return the mime type
 
@@ -155,20 +155,20 @@ declare module 'koa' {
     writable: boolean,
 
     // charset: string,  // doesn't find in response.js
-    length: number |  void,
+    length: number | void,
 
     append: (field: string, val: string | string[]) => void,
     attachment: (filename?: string) => void,
     get: (field: string) => string,
     // https://github.com/jshttp/type-is/blob/master/test/test.js
     // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L382
-    is: ((arg: string[]) => false |  string) &
+    is: ((arg: string[]) => false | string) &
       ((arg: string, ...args: string[]) => false | string) &
       (() => string), // should return the mime type
     redirect: (url: string, alt?: string) => void,
     remove: (field: string) => void,
     // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L418
-    set: ((field: string, val: string | string[]) => void)  &
+    set: ((field: string, val: string | string[]) => void) &
       ((field: {[key: string]: string | string[]}) => void),
 
     vary: (field: string) => void,
@@ -202,12 +202,12 @@ declare module 'koa' {
     overwrite?: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
   };
   declare type Cookies = {
-    get: (name: string, options?: {signed: boolean}) => string |  void,
+    get: (name: string, options?: {signed: boolean}) => string | void,
     set: ((
       name: string,
       value: string,
       options?: CookiesSetOptions
-    ) => Context)  &
+    ) => Context) &
       // delete cookie (an outbound header with an expired date is used.)
       ((name: string) => Context),
   };
@@ -296,7 +296,7 @@ declare module 'koa' {
   declare type Middleware = (
     ctx: Context,
     next: () => Promise<void>
-  ) => Promise<void> |  void;
+  ) => Promise<void> | void;
   declare type ApplicationJSON = {
     subdomainOffset: mixed,
     proxy: mixed,
@@ -310,7 +310,7 @@ declare module 'koa' {
       res: http$ServerResponse
     ) => void;
     env: string;
-    keys?: Array<string>  | Object; // https://github.com/crypto-utils/keygrip
+    keys?: Array<string> | Object; // https://github.com/crypto-utils/keygrip
     middleware: Array<Middleware>;
     proxy: boolean; // when true proxy header fields will be trusted
     request: Request;

--- a/fusion-core/flow-typed/npm/koa_v2.x.x.js
+++ b/fusion-core/flow-typed/npm/koa_v2.x.x.js
@@ -1,0 +1,328 @@
+// @flow
+// flow-typed signature: 2f74d7a92ea1e01e4ee797c15673b1b1
+// flow-typed version: 14fe0603a9/koa_v2.x.x/flow_>=v0.94.x
+
+/*
+ * Type def from from source code of koa.
+ * this: https://github.com/koajs/koa/commit/08eb1a20c3975230aa1fe1c693b0cd1ac7a0752b
+ * previous: https://github.com/koajs/koa/commit/fabf5864c6a5dca0782b867a263b1b0825a05bf9
+ *
+ * Changelog
+ * breaking: remove unused app.name
+ * breaking: ctx.throw([status], [msg], [properties]) (caused by http-errors (#957) )
+ **/
+declare module 'koa' {
+  declare type JSON =
+    | string
+    | number
+    | boolean
+    | null
+    | typeof undefined
+    | JSONObject
+    | JSONArray;
+  declare type JSONObject = {[key: string]: JSON};
+  declare type JSONArray = Array<JSON>;
+
+  declare type SimpleHeader = {
+    'set-cookie'?: Array<string>,
+    [key: string]: string,
+  };
+
+  declare type RequestJSON = {
+    method: string,
+    url: string,
+    header: SimpleHeader,
+  };
+  declare type RequestInspect = void |  RequestJSON;
+  declare type Request = {
+    app: Application,
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    ctx: Context,
+    response: Response,
+
+    fresh: boolean,
+    header: SimpleHeader,
+    headers: SimpleHeader, // alias as header
+    host: string,
+    hostname: string,
+    href: string,
+    idempotent: boolean,
+    ip: string,
+    ips: string[],
+    method: string,
+    origin: string,
+    originalUrl: string,
+    path: string,
+    protocol: string,
+    query: {[key: string]: string}, // always string
+    querystring: string,
+    search: string,
+    secure: boolean, // Shorthand for ctx.protocol == "https" to check if a request was issued via TLS.
+    socket: net$Socket,
+    stale: boolean,
+    subdomains: string[],
+    type: string,
+    url: string,
+
+    charset: string  | void,
+    length: number |  void,
+
+    //  Those functions comes from https://github.com/jshttp/accepts/blob/master/index.js
+    //  request.js$L445
+    //  https://github.com/jshttp/accepts/blob/master/test/type.js
+    accepts: ((args: string[]) => string  | false)  &
+      // ToDo: There is an issue https://github.com/facebook/flow/issues/3009
+      // if you meet some error here, temporarily add an additional annotation
+      // like: `request.accepts((['json', 'text']:Array<string>))` to fix it.
+      ((arg: string, ...args: string[]) => string | false) &
+      (() => string[]), // return the old value.
+
+    //  https://github.com/jshttp/accepts/blob/master/index.js#L153
+    //  https://github.com/jshttp/accepts/blob/master/test/charset.js
+    acceptsCharsets: ((args: string[]) => buffer$Encoding | false)  &
+      // ToDo: https://github.com/facebook/flow/issues/3009
+      // if you meet some error here, see L70.
+      ((arg: string, ...args: string[]) => buffer$Encoding | false) &
+      (() => string[]),
+
+    //  https://github.com/jshttp/accepts/blob/master/index.js#L119
+    //  https://github.com/jshttp/accepts/blob/master/test/encoding.js
+    acceptsEncodings: ((args: string[]) => string | false)  &
+      // ToDo: https://github.com/facebook/flow/issues/3009
+      // if you meet some error here, see L70.
+      ((arg: string, ...args: string[]) => string | false) &
+      (() => string[]),
+
+    //  https://github.com/jshttp/accepts/blob/master/index.js#L185
+    //  https://github.com/jshttp/accepts/blob/master/test/language.js
+    acceptsLanguages: ((args: string[]) => string |  false) &
+      // ToDo: https://github.com/facebook/flow/issues/3009
+      // if you meet some error here, see L70.
+      ((arg: string, ...args: string[]) => string | false) &
+      (() => string[]),
+
+    get: (field: string) => string,
+
+    /* https://github.com/jshttp/type-is/blob/master/test/test.js
+     * Check if the incoming request contains the "Content-Type"
+     * header field, and it contains any of the give mime `type`s.
+     * If there is no request body, `null` is returned.
+     * If there is no content type, `false` is returned.
+     * Otherwise, it returns the first `type` that matches.
+     */
+    is: ((args: string[]) => null | false | string)  &
+      ((arg: string, ...args: string[]) => null | false | string) &
+      (() => string), // should return the mime type
+
+    toJSON: () => RequestJSON,
+    inspect: () => RequestInspect,
+
+    [key: string]: mixed, // props added by middlewares.
+  };
+
+  declare type ResponseJSON = {
+    status: mixed,
+    message: mixed,
+    header: mixed,
+  };
+  declare type ResponseInspect = {
+    status: mixed,
+    message: mixed,
+    header: mixed,
+    body: mixed,
+  };
+  declare type Response = {
+    app: Application,
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    ctx: Context,
+    request: Request,
+
+    // docs/api/response.md#L113.
+    body: string | Buffer | stream$Stream | JSONObject | JSONArray | null, // JSON contains null
+    etag: string,
+    header: SimpleHeader,
+    headers: SimpleHeader, // alias as header
+    headerSent: boolean,
+    // can be set with string|Date, but get with Date.
+    // set lastModified(v: string|Date), // 0.36 doesn't support this.
+    lastModified: Date,
+    message: string,
+    socket: net$Socket,
+    status: number,
+    type: string,
+    writable: boolean,
+
+    // charset: string,  // doesn't find in response.js
+    length: number |  void,
+
+    append: (field: string, val: string | string[]) => void,
+    attachment: (filename?: string) => void,
+    get: (field: string) => string,
+    // https://github.com/jshttp/type-is/blob/master/test/test.js
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L382
+    is: ((arg: string[]) => false |  string) &
+      ((arg: string, ...args: string[]) => false | string) &
+      (() => string), // should return the mime type
+    redirect: (url: string, alt?: string) => void,
+    remove: (field: string) => void,
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L418
+    set: ((field: string, val: string | string[]) => void)  &
+      ((field: {[key: string]: string | string[]}) => void),
+
+    vary: (field: string) => void,
+
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L519
+    toJSON(): ResponseJSON,
+    inspect(): ResponseInspect,
+
+    [key: string]: mixed, // props added by middlewares.
+  };
+
+  declare type ContextJSON = {
+    request: RequestJSON,
+    response: ResponseJSON,
+    app: ApplicationJSON,
+    originalUrl: string,
+    req: '<original node req>',
+    res: '<original node res>',
+    socket: '<original node socket>',
+  };
+  // https://github.com/pillarjs/cookies
+  declare type CookiesSetOptions = {
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
+    expires?: Date, //cookie's expiration date (expires at the end of session by default).
+    path?: string, //  the path of the cookie (/ by default).
+    secure?: boolean, // false by default for HTTP, true by default for HTTPS
+    httpOnly?: boolean, //  a boolean indicating whether the cookie is only to be sent over HTTP(S),
+    // and not made available to client JavaScript (true by default).
+    signed?: boolean, // whether the cookie is to be signed (false by default)
+    overwrite?: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
+  };
+  declare type Cookies = {
+    get: (name: string, options?: {signed: boolean}) => string |  void,
+    set: ((
+      name: string,
+      value: string,
+      options?: CookiesSetOptions
+    ) => Context)  &
+      // delete cookie (an outbound header with an expired date is used.)
+      ((name: string) => Context),
+  };
+  // The default props of context come from two files
+  // `application.createContext` & `context.js`
+  declare type Context = {
+    accept: $PropertyType<Request, 'accept'>,
+    app: Application,
+    cookies: Cookies,
+    name?: string, // ?
+    originalUrl: string,
+    req: http$IncomingMessage<>,
+    request: Request,
+    res: http$ServerResponse,
+    respond?: boolean, // should not be used, allow bypassing koa application.js#L193
+    response: Response,
+    state: {[string]: any},
+
+    // context.js#L55
+    assert: (
+      test: mixed,
+      status: number,
+      message?: string,
+      opts?: mixed
+    ) => void,
+    // context.js#L107
+    // if (!(err instanceof Error)) err = new Error(`non-error thrown: ${err}`);
+    onerror: (err?: mixed) => void,
+    // context.md#L88
+    throw: (status: number, msg?: string, opts?: {}) => void,
+    toJSON(): ContextJSON,
+    inspect(): ContextJSON,
+
+    // ToDo: add const for some props,
+    // while the `const props` feature of Flow is landing in future
+    // cherry pick from response
+    attachment: $PropertyType<Response, 'attachment'>,
+    redirect: $PropertyType<Response, 'redirect'>,
+    remove: $PropertyType<Response, 'remove'>,
+    vary: $PropertyType<Response, 'vary'>,
+    set: $PropertyType<Response, 'set'>,
+    append: $PropertyType<Response, 'append'>,
+    flushHeaders: $PropertyType<Response, 'flushHeaders'>,
+    status: $PropertyType<Response, 'status'>,
+    message: $PropertyType<Response, 'message'>,
+    body: $PropertyType<Response, 'body'>,
+    length: $PropertyType<Response, 'length'>,
+    type: $PropertyType<Response, 'type'>,
+    lastModified: $PropertyType<Response, 'lastModified'>,
+    etag: $PropertyType<Response, 'etag'>,
+    headerSent: $PropertyType<Response, 'headerSent'>,
+    writable: $PropertyType<Response, 'writable'>,
+
+    // cherry pick from request
+    acceptsLanguages: $PropertyType<Request, 'acceptsLanguages'>,
+    acceptsEncodings: $PropertyType<Request, 'acceptsEncodings'>,
+    acceptsCharsets: $PropertyType<Request, 'acceptsCharsets'>,
+    accepts: $PropertyType<Request, 'accepts'>,
+    get: $PropertyType<Request, 'get'>,
+    is: $PropertyType<Request, 'is'>,
+    querystring: $PropertyType<Request, 'querystring'>,
+    idempotent: $PropertyType<Request, 'idempotent'>,
+    socket: $PropertyType<Request, 'socket'>,
+    search: $PropertyType<Request, 'search'>,
+    method: $PropertyType<Request, 'method'>,
+    query: $PropertyType<Request, 'query'>,
+    path: $PropertyType<Request, 'path'>,
+    url: $PropertyType<Request, 'url'>,
+    origin: $PropertyType<Request, 'origin'>,
+    href: $PropertyType<Request, 'href'>,
+    subdomains: $PropertyType<Request, 'subdomains'>,
+    protocol: $PropertyType<Request, 'protocol'>,
+    host: $PropertyType<Request, 'host'>,
+    hostname: $PropertyType<Request, 'hostname'>,
+    header: $PropertyType<Request, 'header'>,
+    headers: $PropertyType<Request, 'headers'>,
+    secure: $PropertyType<Request, 'secure'>,
+    stale: $PropertyType<Request, 'stale'>,
+    fresh: $PropertyType<Request, 'fresh'>,
+    ips: $PropertyType<Request, 'ips'>,
+    ip: $PropertyType<Request, 'ip'>,
+
+    [key: string]: any, // props added by middlewares.
+  };
+
+  declare type Middleware = (
+    ctx: Context,
+    next: () => Promise<void>
+  ) => Promise<void> |  void;
+  declare type ApplicationJSON = {
+    subdomainOffset: mixed,
+    proxy: mixed,
+    env: string,
+  };
+  declare class Application extends events$EventEmitter {
+    context: Context;
+    // request handler for node's native http server.
+    callback: () => (
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse
+    ) => void;
+    env: string;
+    keys?: Array<string>  | Object; // https://github.com/crypto-utils/keygrip
+    middleware: Array<Middleware>;
+    proxy: boolean; // when true proxy header fields will be trusted
+    request: Request;
+    response: Response;
+    server: http$Server;
+    subdomainOffset: number;
+
+    listen: $PropertyType<http$Server, 'listen'>;
+    toJSON(): ApplicationJSON;
+    inspect(): ApplicationJSON;
+    use(fn: Middleware): this;
+  }
+
+  declare module.exports: Class<Application>;
+}

--- a/fusion-core/flow-typed/tape-cup_v4.x.x.js
+++ b/fusion-core/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,125 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts =
+  | {
+      skip: boolean,
+      timeout?: number,
+    }
+  | {
+      skip?: boolean,
+      timeout: number,
+    };
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (
+  a: string | tape$TestOpts | tape$TestCb,
+  b?: tape$TestOpts | tape$TestCb,
+  c?: tape$TestCb
+) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void;
+  pass(msg?: string): void;
+
+  error(err: mixed, msg?: string): void;
+  ifError(err: mixed, msg?: string): void;
+  ifErr(err: mixed, msg?: string): void;
+  iferror(err: mixed, msg?: string): void;
+
+  ok(value: mixed, msg?: string): void;
+  true(value: mixed, msg?: string): void;
+  assert(value: mixed, msg?: string): void;
+
+  notOk(value: mixed, msg?: string): void;
+  false(value: mixed, msg?: string): void;
+  notok(value: mixed, msg?: string): void;
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void;
+  equals(actual: mixed, expected: mixed, msg?: string): void;
+  isEqual(actual: mixed, expected: mixed, msg?: string): void;
+  is(actual: mixed, expected: mixed, msg?: string): void;
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquals(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNot(actual: mixed, expected: mixed, msg?: string): void;
+  not(actual: mixed, expected: mixed, msg?: string): void;
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  same(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  notSame(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  throws(fn: Function, msg?: string): void;
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  doesNotThrow(fn: Function, msg?: string): void;
+
+  timeoutAfter(ms: number): void;
+
+  skip(msg?: string): void;
+  plan(n: number): void;
+  onFinish(fn: Function): void;
+  end(): void;
+  comment(msg: string): void;
+  test: tape$TestFn;
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+  declare type TestCb = tape$TestCb;
+  declare type tape$TestCb = tape$TestCb;
+
+  declare type Tape = {
+    (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/fusion-core/package.json
+++ b/fusion-core/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "flow-typed"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",

--- a/fusion-plugin-i18n/flow-typed/globals.js
+++ b/fusion-plugin-i18n/flow-typed/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/fusion-plugin-i18n/flow-typed/locale.js
+++ b/fusion-plugin-i18n/flow-typed/locale.js
@@ -1,0 +1,41 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare module 'locale' {
+  declare class Locale {
+    constructor(str: string): Locale;
+
+    code: string;
+    language: string;
+    country: string;
+    normalized: string;
+    score: number;
+    defaulted: boolean;
+
+    serialize: Function;
+    toString: Function;
+    toJSON: Function;
+  }
+
+  declare class Locales {
+    constructor(str: string[] | string, def?: string): Locales;
+
+    length: number;
+    _index: any;
+    index: Function;
+
+    best: (locales: Locales) => Locale;
+
+    sort: Function;
+    push: Function;
+
+    serialize: Function;
+    toString: Function;
+    toJSON: Function;
+  }
+}

--- a/fusion-plugin-i18n/flow-typed/tape-cup_v4.x.x.js
+++ b/fusion-plugin-i18n/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,125 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts =
+  | {
+      skip: boolean,
+      timeout?: number,
+    }
+  | {
+      skip?: boolean,
+      timeout: number,
+    };
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (
+  a: string | tape$TestOpts | tape$TestCb,
+  b?: tape$TestOpts | tape$TestCb,
+  c?: tape$TestCb
+) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void;
+  pass(msg?: string): void;
+
+  error(err: mixed, msg?: string): void;
+  ifError(err: mixed, msg?: string): void;
+  ifErr(err: mixed, msg?: string): void;
+  iferror(err: mixed, msg?: string): void;
+
+  ok(value: mixed, msg?: string): void;
+  true(value: mixed, msg?: string): void;
+  assert(value: mixed, msg?: string): void;
+
+  notOk(value: mixed, msg?: string): void;
+  false(value: mixed, msg?: string): void;
+  notok(value: mixed, msg?: string): void;
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void;
+  equals(actual: mixed, expected: mixed, msg?: string): void;
+  isEqual(actual: mixed, expected: mixed, msg?: string): void;
+  is(actual: mixed, expected: mixed, msg?: string): void;
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquals(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNot(actual: mixed, expected: mixed, msg?: string): void;
+  not(actual: mixed, expected: mixed, msg?: string): void;
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  same(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  notSame(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  throws(fn: Function, msg?: string): void;
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  doesNotThrow(fn: Function, msg?: string): void;
+
+  timeoutAfter(ms: number): void;
+
+  skip(msg?: string): void;
+  plan(n: number): void;
+  onFinish(fn: Function): void;
+  end(): void;
+  comment(msg: string): void;
+  test: tape$TestFn;
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+  declare type TestCb = tape$TestCb;
+  declare type tape$TestCb = tape$TestCb;
+
+  declare type Tape = {
+    (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/fusion-plugin-i18n/package.json
+++ b/fusion-plugin-i18n/package.json
@@ -10,7 +10,8 @@
   "files": [
     "dist",
     "chunk-translation-map.js",
-    "src"
+    "src",
+    "flow-typed"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",

--- a/fusion-plugin-react-redux/flow-typed/globals.js
+++ b/fusion-plugin-react-redux/flow-typed/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/fusion-plugin-react-redux/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-react-redux/flow-typed/npm/redux_v4.x.x.js
@@ -1,0 +1,100 @@
+// flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
+// flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
+
+declare module 'redux' {
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type Action<T> = {
+    type: T
+  }
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
+
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
+
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/fusion-plugin-react-redux/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-react-redux/flow-typed/npm/redux_v4.x.x.js
@@ -1,3 +1,4 @@
+// @flow
 // flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
 // flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
 
@@ -11,12 +12,12 @@ declare module 'redux' {
   */
 
   declare export type Action<T> = {
-    type: T
-  }
+    type: T,
+  };
 
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+  declare export type Dispatch<A: {type: *}> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,

--- a/fusion-plugin-react-redux/flow-typed/tape-cup_v4.x.x.js
+++ b/fusion-plugin-react-redux/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,125 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts =
+  | {
+      skip: boolean,
+      timeout?: number,
+    }
+  | {
+      skip?: boolean,
+      timeout: number,
+    };
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (
+  a: string | tape$TestOpts | tape$TestCb,
+  b?: tape$TestOpts | tape$TestCb,
+  c?: tape$TestCb
+) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void;
+  pass(msg?: string): void;
+
+  error(err: mixed, msg?: string): void;
+  ifError(err: mixed, msg?: string): void;
+  ifErr(err: mixed, msg?: string): void;
+  iferror(err: mixed, msg?: string): void;
+
+  ok(value: mixed, msg?: string): void;
+  true(value: mixed, msg?: string): void;
+  assert(value: mixed, msg?: string): void;
+
+  notOk(value: mixed, msg?: string): void;
+  false(value: mixed, msg?: string): void;
+  notok(value: mixed, msg?: string): void;
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void;
+  equals(actual: mixed, expected: mixed, msg?: string): void;
+  isEqual(actual: mixed, expected: mixed, msg?: string): void;
+  is(actual: mixed, expected: mixed, msg?: string): void;
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquals(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNot(actual: mixed, expected: mixed, msg?: string): void;
+  not(actual: mixed, expected: mixed, msg?: string): void;
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  same(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  notSame(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  throws(fn: Function, msg?: string): void;
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  doesNotThrow(fn: Function, msg?: string): void;
+
+  timeoutAfter(ms: number): void;
+
+  skip(msg?: string): void;
+  plan(n: number): void;
+  onFinish(fn: Function): void;
+  end(): void;
+  comment(msg: string): void;
+  test: tape$TestFn;
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+  declare type TestCb = tape$TestCb;
+  declare type tape$TestCb = tape$TestCb;
+
+  declare type Tape = {
+    (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/fusion-plugin-react-redux/package.json
+++ b/fusion-plugin-react-redux/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "dist",
+    "flow-typed",
     "src"
   ],
   "main": "./dist/index.js",

--- a/fusion-plugin-redux-action-emitter-enhancer/flow-typed/globals.js
+++ b/fusion-plugin-redux-action-emitter-enhancer/flow-typed/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/fusion-plugin-redux-action-emitter-enhancer/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-redux-action-emitter-enhancer/flow-typed/npm/redux_v4.x.x.js
@@ -1,0 +1,100 @@
+// flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
+// flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
+
+declare module 'redux' {
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type Action<T> = {
+    type: T
+  }
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
+
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
+
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/fusion-plugin-redux-action-emitter-enhancer/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-redux-action-emitter-enhancer/flow-typed/npm/redux_v4.x.x.js
@@ -1,3 +1,4 @@
+// @flow
 // flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
 // flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
 
@@ -11,12 +12,12 @@ declare module 'redux' {
   */
 
   declare export type Action<T> = {
-    type: T
-  }
+    type: T,
+  };
 
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+  declare export type Dispatch<A: {type: *}> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,

--- a/fusion-plugin-redux-action-emitter-enhancer/flow-typed/tape-cup_v4.x.x.js
+++ b/fusion-plugin-redux-action-emitter-enhancer/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,125 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts =
+  | {
+      skip: boolean,
+      timeout?: number,
+    }
+  | {
+      skip?: boolean,
+      timeout: number,
+    };
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (
+  a: string | tape$TestOpts | tape$TestCb,
+  b?: tape$TestOpts | tape$TestCb,
+  c?: tape$TestCb
+) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void;
+  pass(msg?: string): void;
+
+  error(err: mixed, msg?: string): void;
+  ifError(err: mixed, msg?: string): void;
+  ifErr(err: mixed, msg?: string): void;
+  iferror(err: mixed, msg?: string): void;
+
+  ok(value: mixed, msg?: string): void;
+  true(value: mixed, msg?: string): void;
+  assert(value: mixed, msg?: string): void;
+
+  notOk(value: mixed, msg?: string): void;
+  false(value: mixed, msg?: string): void;
+  notok(value: mixed, msg?: string): void;
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void;
+  equals(actual: mixed, expected: mixed, msg?: string): void;
+  isEqual(actual: mixed, expected: mixed, msg?: string): void;
+  is(actual: mixed, expected: mixed, msg?: string): void;
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquals(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNot(actual: mixed, expected: mixed, msg?: string): void;
+  not(actual: mixed, expected: mixed, msg?: string): void;
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isInequal(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void;
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  same(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  notSame(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void;
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void;
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void;
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void;
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void;
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void;
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  throws(fn: Function, msg?: string): void;
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void;
+  doesNotThrow(fn: Function, msg?: string): void;
+
+  timeoutAfter(ms: number): void;
+
+  skip(msg?: string): void;
+  plan(n: number): void;
+  onFinish(fn: Function): void;
+  end(): void;
+  comment(msg: string): void;
+  test: tape$TestFn;
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+  declare type TestCb = tape$TestCb;
+  declare type tape$TestCb = tape$TestCb;
+
+  declare type Tape = {
+    (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (
+      a: string | tape$TestOpts | tape$TestCb,
+      b?: tape$TestCb | tape$TestOpts,
+      c?: tape$TestCb,
+      ...rest: Array<void>
+    ) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/fusion-plugin-redux-action-emitter-enhancer/package.json
+++ b/fusion-plugin-redux-action-emitter-enhancer/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "flow-typed"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",

--- a/fusion-plugin-rpc-redux-react/flow-typed/globals.js
+++ b/fusion-plugin-rpc-redux-react/flow-typed/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/fusion-plugin-rpc-redux-react/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-rpc-redux-react/flow-typed/npm/redux_v4.x.x.js
@@ -1,0 +1,100 @@
+// flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
+// flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
+
+declare module 'redux' {
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type Action<T> = {
+    type: T
+  }
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
+
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
+
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/fusion-plugin-rpc-redux-react/flow-typed/npm/redux_v4.x.x.js
+++ b/fusion-plugin-rpc-redux-react/flow-typed/npm/redux_v4.x.x.js
@@ -1,3 +1,4 @@
+// @flow
 // flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
 // flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
 
@@ -11,12 +12,12 @@ declare module 'redux' {
   */
 
   declare export type Action<T> = {
-    type: T
-  }
+    type: T,
+  };
 
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+  declare export type Dispatch<A: {type: *}> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,

--- a/fusion-plugin-rpc-redux-react/flow-typed/redux-reactors_v1.x.x.js
+++ b/fusion-plugin-rpc-redux-react/flow-typed/redux-reactors_v1.x.x.js
@@ -1,0 +1,16 @@
+// @flow
+
+/* eslint-disable  */
+
+declare module 'redux-reactors' {
+  import type {Reducer, StoreCreator} from 'redux';
+
+  declare type Reactor<TType, TPayload> = (payload: TPayload) => ({
+    type: TType,
+    payload: TPayload,
+    __REACTOR__: boolean
+  });
+  declare function createReactor<TType>(type: TType, reducer: Reducer<*, *>): Reactor<TType, *>;
+
+  declare function reactorEnhancer(createStore: StoreCreator<*, *, *>): StoreCreator<*, *, *>;
+}

--- a/fusion-plugin-rpc-redux-react/package.json
+++ b/fusion-plugin-rpc-redux-react/package.json
@@ -13,6 +13,7 @@
     "dist-browser-esm",
     "dist-node-cjs",
     "dist-node-esm",
+    "flow-typed",
     "src"
   ],
   "main": "./dist-node-cjs/index.js",


### PR DESCRIPTION
Adds back in relevant `libdef` files in `flow-typed/` directories for packages that used to export their `flow-typed/`.

Avoids a breaking change until codemods can handle this more seamlessly.