### PR TITLE
Add Jest to dev dependencies for fusion-plugin-connected-react-router

### DIFF
--- a/fusion-plugin-connected-react-router/package.json
+++ b/fusion-plugin-connected-react-router/package.json
@@ -54,6 +54,7 @@
     "fusion-react": "0.0.0-monorepo",
     "fusion-test-utils": "0.0.0-monorepo",
     "get-port": "^5.0.0",
+    "jest": "^24.8.0",
     "nyc": "^14.1.0",
     "prettier": "^1.18.2",
     "puppeteer": "^1.15.0",


### PR DESCRIPTION
As an isolated package, the test scripts reference Jest but the package is never actually installed. 

This seems to work fine in Rush as binaries seem to be shared across the entire repo but when testing Jazelle it breaks since the individual package is missing Jest.