### PR TITLE
Add jest as a devDep rpc_redux_react

### DIFF
--- a/fusion-plugin-rpc-redux-react/package.json
+++ b/fusion-plugin-rpc-redux-react/package.json
@@ -54,6 +54,7 @@
     "fusion-test-utils": "0.0.0-monorepo",
     "fusion-tokens": "0.0.0-monorepo",
     "get-port": "^5.0.0",
+    "jest": "^24.8.0",
     "nyc": "^14.1.0",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Same deal as pull #531 .

As an isolated package, the test scripts reference Jest but the package is never actually installed.

This seems to work fine in Rush as binaries seem to be shared across the entire repo but when testing Jazelle it breaks since the individual package is missing Jest.