### PR TITLE
Update fusion-plugin-apollo to pass custom executor

### DIFF
--- a/fusion-plugin-apollo/src/__tests__/integration.node.js
+++ b/fusion-plugin-apollo/src/__tests__/integration.node.js
@@ -11,6 +11,7 @@ import {
   ApolloRenderEnhancer,
   GraphQLSchemaToken,
   ApolloClientToken,
+  ApolloClientPlugin,
   ApolloBodyParserConfigToken,
 } from '../index';
 import gql from 'graphql-tag';
@@ -43,10 +44,7 @@ async function testApp(el, {typeDefs, resolvers}, enhanceApp) {
   });
   app.enhance(RenderToken, ApolloRenderEnhancer);
   app.register(GraphQLSchemaToken, schema);
-  app.register(ApolloClientToken, ctx => {
-    // $FlowFixMe
-    return {}; // should hit server
-  });
+  app.register(ApolloClientToken, ApolloClientPlugin);
   if (enhanceApp) {
     enhanceApp(app);
   }

--- a/fusion-plugin-apollo/src/plugin.js
+++ b/fusion-plugin-apollo/src/plugin.js
@@ -126,6 +126,26 @@ export default (renderFn: Render) =>
             }
             return apolloContext;
           },
+          executor: requestContext => {
+            const client = getApolloClient(requestContext.context, {});
+            const args = {
+              variables: requestContext.request.variables,
+              context: requestContext.context,
+            };
+            if (requestContext.operation.operation === 'query') {
+              return client.query({
+                query: requestContext.document,
+                ...args,
+              });
+            } else if (requestContext.operation.operation === 'mutation') {
+              return client.mutate({
+                mutation: requestContext.document,
+                ...args,
+              });
+            } else {
+              throw new Error('Subscriptions not supported yet');
+            }
+          },
         });
         let serverMiddleware = [];
         server.applyMiddleware({


### PR DESCRIPTION
Passing a custom executor to fusion-plugin-apollo allows the code path for executing graphql queries to always use apollo-client, which means custom links can be implemented to wrap queries executed on SSR and queries POSTed to `/graphql`.