### PR TITLE
Implement bump command

### DIFF
--- a/jazelle/README.md
+++ b/jazelle/README.md
@@ -338,6 +338,11 @@ If you get into a bad state, here are some things you can try:
 - [`jazelle test`](#jazelle-test)
 - [`jazelle lint`](#jazelle-lint)
 - [`jazelle flow`](#jazelle-flow)
+- [`jazelle start`](#jazelle-start)
+- [`jazelle bazel`](#jazelle-bazel)
+- [`jazelle yarn`](#jazelle-yarn)
+- [`jazelle bump`](#jazelle-bump)
+- [`jazelle doctor`](#jazelle-doctor)
 - [Running NPM scripts](#running-npm-scripts)
 - [Colorized errors](#colorized-errors)
 
@@ -553,6 +558,18 @@ Runs a Yarn command
 - `--cwd` - Project folder (absolute or relative to shell `cwd`). Defaults to `process.cwd()`
 - `args` - A space separated list of Yarn arguments
 
+### `jazelle bump`
+
+Bumps a package and its dependencies to the next version. It also updates all matching local packages to match
+
+`jazelle bump [type] [--frozePackageJson] --cwd [cwd]`
+
+- `type` - Must be one of `major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, `prerelease` or `none`
+- `frozenPackageJson` - If this flag is present, throws if changes to package.json are required. Useful for warning users to commit version bumps before publishing
+- `--cwd` - Project folder (absolute or relative to shell `cwd`). Defaults to `process.cwd()`
+
+The bump command is idempotent, i.e. running it twice without publishing results in the same versions.
+
 ### `jazelle doctor`
 
 Suggests fixes for some types of issues
@@ -595,6 +612,7 @@ If you want commands to display colorized output, run their respective NPM scrip
 - [flow](#flow)
 - [bazel](#bazel)
 - [yarn](#yarn)
+- [bump](#bump)
 - [doctor](#doctor)
 - [getRootDir](#getRootDir)
 
@@ -840,6 +858,19 @@ Runs a Yarn command
 - `cwd` - Project folder (absolute path)
 - `command`- A Yarn command (e.g. `add`)
 - `args` - List of Yarn args
+
+### `bump`
+
+Bumps a package and its dependencies to the next version. It also updates all matching local packages to match
+
+`let bump = ({root: string, cwd: string, type: string, frozenPackageJson?: boolean})`
+
+- `root` - Monorepo root folder (absolute path)
+- `cwd` - Project folder (absolute path)
+- `type` - Must be one of `major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, `prerelease` or `none`
+- `frozenPackageJson` - If true, throws if changes to package.json are required. Useful for warning users to commit version bumps before publishing. Defaults to false.
+
+The bump command is idempotent, i.e. running it twice without publishing results in the same versions.
 
 ### `doctor`
 

--- a/jazelle/commands/bump.js
+++ b/jazelle/commands/bump.js
@@ -1,0 +1,78 @@
+// @flow
+const {inc} = require('semver');
+const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {getManifest} = require('../utils/get-manifest.js');
+const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
+const {exec, write} = require('../utils/node-helpers.js');
+const {node, yarn} = require('../utils/binary-paths.js');
+const {greenkeep} = require('./greenkeep.js');
+
+/*::
+type BumpArgs = {
+  root: string,
+  cwd: string,
+  type: string,
+  frozenPackageJson?: boolean,
+}
+type Bump = (BumpArgs) => Promise<void>
+*/
+
+const bump /*: Bump */ = async ({
+  root,
+  cwd,
+  type,
+  frozenPackageJson = false,
+}) => {
+  await assertProjectDir({dir: cwd});
+
+  const {projects} = await getManifest({root});
+  const deps = await getLocalDependencies({
+    dirs: projects.map(dir => `${root}/${dir}`),
+    target: cwd,
+  });
+
+  const types = /^(major|premajor|minor|preminor|patch|prepatch|prerelease|none)$/;
+  if (!types.test(type)) {
+    throw new Error(
+      `Invalid bump type: ${type}. Must be major, premajor, minor, preminor, patch, prepatch, prerelease or none`
+    );
+  }
+
+  for (const dep of deps) {
+    const query = `${node} ${yarn} info ${dep.meta.name} versions --json`;
+    const data = await exec(query, {cwd: root, env: process.env});
+    const version = parseVersion(data);
+    const old = dep.meta.version;
+    const next = type === 'none' ? version : inc(version, type);
+
+    if (next !== old) {
+      if (frozenPackageJson) {
+        throw new Error(
+          `Cannot bump version when frozenPackageJson is true. You most likely forgot to bump a dependency's version locally`
+        );
+      }
+
+      dep.meta.version = next;
+      await write(
+        `${dep.dir}/package.json`,
+        JSON.stringify(dep.meta, null, 2),
+        'utf8'
+      );
+
+      await greenkeep({
+        root,
+        cwd,
+        name: dep.meta.name,
+        version: dep.meta.version,
+        from: old,
+      });
+    }
+  }
+};
+
+const parseVersion = data => {
+  const versions = data ? JSON.parse(data).data : [];
+  return versions.length > 0 ? versions.pop() : '0.0.0';
+};
+
+module.exports = {bump};

--- a/jazelle/index.js
+++ b/jazelle/index.js
@@ -22,6 +22,7 @@ const {flow} = require('./commands/flow.js');
 const {start} = require('./commands/start.js');
 const {yarn} = require('./commands/yarn.js');
 const {bazel} = require('./commands/bazel.js');
+const {bump} = require('./commands/bump.js');
 const {doctor} = require('./commands/doctor.js');
 const {
   reportMismatchedTopLevelDeps,
@@ -173,7 +174,16 @@ const runCLI /*: RunCLI */ = async argv => {
         [name]                  A yarn command name
         [args...]               A space separated list of arguments
         --cwd [cwd]             Project directory to use`,
-        async ({cwd, name}) => yarn({cwd, args: rest}),
+        async ({cwd}) => yarn({cwd, args: rest}),
+      ],
+      bump: [
+        `Bump version for the specified package, plus changed dependencies
+
+        [type]                  major, premajor, minor, preminor, patch, prepatch, prerelease or none
+        --frozenPackageJson     If true, throws if changes to package.json are required
+        --cwd [cwd]             Project directory to use`,
+        async ({cwd, name: type, frozenPackageJson: frozen}) =>
+          bump({root, cwd, type, frozenPackageJson: Boolean(frozen)}),
       ],
       doctor: [
         `Provides advice for some types of issues
@@ -209,6 +219,7 @@ module.exports = {
   start,
   bazel,
   yarn,
+  bump,
   doctor,
   getRootDir,
 };

--- a/jazelle/tests/fixtures/bump/manifest.json
+++ b/jazelle/tests/fixtures/bump/manifest.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    "not-a-real-project",
+    "not-a-real-dep"
+  ]
+}

--- a/jazelle/tests/fixtures/bump/not-a-real-dep/package.json
+++ b/jazelle/tests/fixtures/bump/not-a-real-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "not-a-real-dep",
+  "version": "0.0.0"
+}

--- a/jazelle/tests/fixtures/bump/not-a-real-downstream/package.json
+++ b/jazelle/tests/fixtures/bump/not-a-real-downstream/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "not-a-real-downstream",
+  "version": "0.0.0",
+  "dependencies": {
+    "not-a-real-project": "0.0.0"
+  }
+}

--- a/jazelle/tests/fixtures/bump/not-a-real-project/package.json
+++ b/jazelle/tests/fixtures/bump/not-a-real-project/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "not-a-real-project",
+  "version": "0.0.0",
+  "dependencies": {
+    "not-a-real-dep": "0.0.0"
+  }
+}


### PR DESCRIPTION
Implement bump command

TL;DR:

`cd my-project && jazelle bump minor` bumps `my-project` by a minor version, plus all of its local dependencies by a minor version

- Local packages that depend on the bumped packages are automatically greenkept
- All deltas supported by `semver.inc()` are supported (major, minor, patch, premajor, preminor, prepatch, prerelease), as well as `none` (useful to undo a bump or reset version definitions to match the registry)
- The version delta is from the published version (not from what's in package.json), therefore:
- Running the command multiple times is idempotent (i.e. running the command always result in the same `git diff` until the new versions are published).
- The command has a `--frozenPackageJson` flag. If true, the command throws if a version bump requires updating a package.json file. This is useful in CI: we can run `jazelle bump [type] --frozenPackageJson` to block a publish if it were going to miss local dependency bumps.