### PR TITLE
Fix CLI script to always respect WORKSPACE

### DIFF
--- a/jazelle/bin/cli.sh
+++ b/jazelle/bin/cli.sh
@@ -10,7 +10,7 @@ fi
 findroot() {
   if [ -f "WORKSPACE" ]
   then
-    echo "$PWD/WORKSPACE"
+    echo "$PWD/"
   elif [ "$PWD" = "/" ]
   then
     echo ""
@@ -28,13 +28,7 @@ then
 fi
 
 # setup other binaries
-if [ -d "$ROOT" ] && [ ! -d "$ROOT/bazel-bin/jazelle.runfiles/jazelle_dependencies" ]
-then
-  echo "Setting up Bazel, Node and Yarn"
-  # trigger Bazel repository rules to download node and yarn
-  # then print bazel version info
-  "$BIN/bazelisk" run //:jazelle bazel version
-fi
+"$BIN/bazelisk" run //:jazelle -- noop 2>/dev/null
 
 NODE="$ROOT/bazel-bin/jazelle.runfiles/jazelle_dependencies/bin/node"
 YARN="$ROOT/bazel-bin/jazelle.runfiles/jazelle_dependencies/bin/yarn.js"
@@ -43,6 +37,7 @@ JAZELLE="$ROOT/bazel-bin/jazelle.runfiles/jazelle"
 # if we can't find Bazel workspace, fall back to system node and jazelle's pinned yarn
 if [ ! -f "$NODE" ] || [ ! -f "$YARN" ] || [ ! -d "$JAZELLE" ]
 then
+  echo "Warning: using global Jazelle. Builds may not be reproducible."
   if [ ! -f "$BIN/yarn.js" ]
   then
     "$NODE" "$BIN/../utils/download-yarn.js"

--- a/jazelle/index.js
+++ b/jazelle/index.js
@@ -192,7 +192,7 @@ const runCLI /*: RunCLI */ = async argv => {
         async ({cwd}) => doctor({root, cwd}),
       ],
     },
-    async ({cwd}) => yarn({cwd, args: [command, ...rest]})
+    async () => {}
   );
 };
 

--- a/jazelle/package.json
+++ b/jazelle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.1",
+  "version": "0.0.0-monorepo",
   "license": "UNLICENSED",
   "main": "index.js",
   "bin": {

--- a/jazelle/tests/fixtures/bump/manifest.json
+++ b/jazelle/tests/fixtures/bump/manifest.json
@@ -1,5 +1,6 @@
 {
   "projects": [
+    "not-a-real-downstream",
     "not-a-real-project",
     "not-a-real-dep"
   ]


### PR DESCRIPTION
TL;DR: always use monorepo's jazelle version regardless of global Jazelle version

- fix bin script to always respect WORKSPACE
- add warning if falling back to global jazelle
- remove implicit yarn command fallback
- make version consistent w/ monorepo convention
- fix fixture

