### PR TITLE
Clean up typing for Tokens

### DIFF
--- a/fusion-core/src/base-app.js.flow
+++ b/fusion-core/src/base-app.js.flow
@@ -9,7 +9,7 @@
 import type {
   aliaser,
   cleanupFn,
-  ExtractReturnType,
+  ExtractTokenType,
   FusionPlugin,
   Middleware,
   Token,
@@ -33,7 +33,7 @@ declare class FusionApp {
   register<TVal>(token: Token<TVal>, val: TVal): aliaser<Token<*>>;
   middleware<TDeps>(
     deps: TDeps,
-    middleware: (Deps: $ObjMap<TDeps, ExtractReturnType>) => Middleware
+    middleware: (Deps: $ObjMap<TDeps, ExtractTokenType>) => Middleware
   ): void;
   middleware(middleware: Middleware): void;
   callback(): (...Array<*>) => Promise<void> | any;

--- a/fusion-core/src/index.js
+++ b/fusion-core/src/index.js
@@ -7,6 +7,7 @@
  */
 import type {
   Context,
+  ExtractTokenType,
   FusionPlugin,
   Middleware,
   Token,
@@ -59,6 +60,7 @@ type FusionApp = typeof BaseApp;
 declare export default typeof BaseApp;
 export type {
   Context,
+  ExtractTokenType,
   FusionApp,
   FusionPlugin,
   Middleware,

--- a/fusion-core/src/types.js
+++ b/fusion-core/src/types.js
@@ -47,18 +47,18 @@ export type Middleware = (
 ) => Promise<*>;
 
 export type MiddlewareWithDeps<Deps> = (
-  Deps: $ObjMap<Deps, ExtractReturnType>
+  Deps: $ObjMap<Deps, ExtractTokenType>
 ) => Middleware;
 
-export type ExtractReturnType = <V>(() => V) => V;
+export type ExtractTokenType = <V>(() => V) => V;
 
 export type FusionPlugin<Deps, Service> = {|
   __plugin__: boolean,
   stack: string,
   deps?: Deps,
-  provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,
+  provides?: (Deps: $ObjMap<Deps & {}, ExtractTokenType>) => Service,
   middleware?: (
-    Deps: $ObjMap<Deps & {}, ExtractReturnType>,
+    Deps: $ObjMap<Deps & {}, ExtractTokenType>,
     Service: Service
   ) => Middleware,
   cleanup?: (service: Service) => Promise<void>,

--- a/fusion-core/src/types.js
+++ b/fusion-core/src/types.js
@@ -50,7 +50,7 @@ export type MiddlewareWithDeps<Deps> = (
   Deps: $ObjMap<Deps, ExtractTokenType>
 ) => Middleware;
 
-export type ExtractTokenType = <V>(() => V) => V;
+export type ExtractTokenType = <V>(Token<V>) => V;
 
 export type FusionPlugin<Deps, Service> = {|
   __plugin__: boolean,


### PR DESCRIPTION
The old way that we extracted the underlying generic service type (T) that a token (Token<T>) provides was as follows:

- We defined the Token type to be a callable function that returns T (even though it isn't one!)
- We used an any cast to coerce created tokens into this type
- We used ExtractReturnType along with $Call to "call" the token type itself

This is fairly unintuitive and roundabout, when we can simply fetch the generic type directly by adjusting the utility function. I also exported it so that others can use it, since not all plugins export their underlying types.