### PR TITLE
Ensure `_diagnostics` route always 200's even after handling payload

### DIFF
--- a/fusion-plugin-introspect/src/server.js
+++ b/fusion-plugin-introspect/src/server.js
@@ -94,6 +94,12 @@ const plugin = (app: App, {store, env = [], deps = {}}: Object = {}) => {
               data.browser = [ctx.request.body]; // as array, to avoid schema break if we ever need to log per-browser graphs
               await store.store(data, deps);
             }
+          } else if (
+            ctx.method === 'POST' &&
+            ctx.path.startsWith('/_diagnostics')
+          ) {
+            ctx.status = 200;
+            ctx.body = 'OK';
           }
           return next();
         };


### PR DESCRIPTION
It's possible for the _diagnostics route to 404 if it receives simultaneous requests from multiple clients. This PR makes the endpoint always return 200