### PR TITLE
Add ability to specify commit range for jazelle changes

### DIFF
--- a/jazelle/README.md
+++ b/jazelle/README.md
@@ -487,6 +487,8 @@ List projects that have changed since the last git commit.
 
 `jazelle changes`
 
+- `--sha1` - The commit SHA-1 to get the list of changes from. Defaults to `HEAD` of the current branch.
+- `--sha2` - If populated, will get the list of changes between `sha1` and `sha2`. Defaults to an empty string.
 - `--type` - If type is `bazel`, it prints Bazel targets. If type is `dirs`, it prints the project folders. Defaults to `dirs`.
 
 Bazel targets can be tested via the `bazel test [target]` command.

--- a/jazelle/commands/changes.js
+++ b/jazelle/commands/changes.js
@@ -4,12 +4,14 @@ const {findChangedTargets} = require('../utils/find-changed-targets.js');
 /*::
 type ChangesArgs = {
   root: string,
-  type: string,
+  sha1?: string,
+  sha2?: string,
+  type?: string,
 };
 type Changes = (ChangesArgs) => Promise<void>;
 */
-const changes /*: Changes */ = async ({root, type}) => {
-  const targets = await findChangedTargets({root, type});
+const changes /*: Changes */ = async ({root, sha1, sha2, type}) => {
+  const targets = await findChangedTargets({root, sha1, sha2, type});
   console.log(targets.join('\n'));
 };
 

--- a/jazelle/index.js
+++ b/jazelle/index.js
@@ -123,8 +123,10 @@ const runCLI /*: RunCLI */ = async argv => {
       changes: [
         `Lists Bazel test targets that changed since the last git commit
 
+        --sha1 [sha1]           List changes since this commit (default is HEAD)
+        --sha2 [sha2]           List changes between sha1 and this commit
         --type [type]           'bazel' or 'dirs'`,
-        ({type}) => changes({root, type}),
+        ({sha1, sha2, type}) => changes({root, sha1, sha2, type}),
       ],
       build: [
         `Build a project

--- a/jazelle/utils/find-changed-targets.js
+++ b/jazelle/utils/find-changed-targets.js
@@ -6,12 +6,19 @@ const {bazel} = require('./binary-paths.js');
 /*::
 export type FindChangedTargetsArgs = {
   root: string,
-  type: string,
+  sha1?: string,
+  sha2?: string,
+  type?: string,
 };
 export type FindChangedTargets = (FindChangedTargetsArgs) => Promise<Array<string>>;
 */
-const findChangedTargets /*: FindChangedTargets */ = async ({root, type}) => {
-  const targets = await findChangedBazelTargets({root});
+const findChangedTargets /*: FindChangedTargets */ = async ({
+  root,
+  sha1,
+  sha2,
+  type,
+}) => {
+  const targets = await findChangedBazelTargets({root, sha1, sha2});
   switch (type) {
     case 'bazel':
       return targets;
@@ -26,10 +33,13 @@ const findChangedTargets /*: FindChangedTargets */ = async ({root, type}) => {
   }
 };
 
-const findChangedBazelTargets = async ({root}) => {
-  const diff = await exec(`git diff-tree --no-commit-id --name-only -r HEAD`, {
-    cwd: root,
-  }).catch(() => null);
+const findChangedBazelTargets = async ({root, sha1 = 'HEAD', sha2 = ''}) => {
+  const diff = await exec(
+    `git diff-tree --no-commit-id --name-only -r ${sha1} ${sha2}`,
+    {
+      cwd: root,
+    }
+  ).catch(() => null);
   const {projects, workspace} = await getManifest({root});
   if (workspace === 'sandbox') {
     if (diff !== null) {


### PR DESCRIPTION
The default behavior of the `changes` command only compares the list of changes from the current commit to its parent. This usually is just the last commit.

This adds the ability to specify a commit range (`--sha1` and `--sha2`). The default behavior is the same as the current behavior in that `--sha1` will default to `HEAD` but this allows for using `git-tree` to compare across a wide range of commits.

This is useful, for example, in CI where for a given pull request, we can utilize the `changes` command to run CI tests on every changed project in a monorepo, no matter how many commits have been made to the branch. Whereas the default behavior would only return the last commit and so the command would only run tests on the last changed project.