### PR TITLE
Don't detect false positive cycles

### DIFF
--- a/jazelle/bin/cli.sh
+++ b/jazelle/bin/cli.sh
@@ -28,7 +28,7 @@ then
 fi
 
 # setup other binaries
-"$BIN/bazelisk" run //:jazelle -- noop #2>/dev/null
+"$BIN/bazelisk" run //:jazelle -- noop 2>/dev/null
 
 NODE="$ROOT/bazel-bin/jazelle.runfiles/jazelle_dependencies/bin/node"
 YARN="$ROOT/bazel-bin/jazelle.runfiles/jazelle_dependencies/bin/yarn.js"


### PR DESCRIPTION
The cyclical dep detection in `jazelle doctor` was catching some false positives. This fixes that