### PR TITLE
Sync private<>public monorepos

### DIFF
--- a/jazelle/README.md
+++ b/jazelle/README.md
@@ -77,7 +77,7 @@ http_archive(
 
 load("@jazelle//:workspace-rules.bzl", "jazelle_dependencies")
 jazelle_dependencies(
-  node_version = "10.15.3",
+  node_version = "10.16.0",
   node_sha256 = {
     "mac": "7a5eaa1f69614375a695ccb62017248e5dcc15b0b8edffa7db5b52997cf992ba",
     "linux": "faddbe418064baf2226c2fcbd038c3ef4ae6f936eb952a1138c7ff8cfe862438",

--- a/jazelle/rules/jazelle-dependencies.bzl
+++ b/jazelle/rules/jazelle-dependencies.bzl
@@ -70,11 +70,11 @@ SHA256s can be found at https://nodejs.org/dist/v[version]/SHASUM256.txt
 - node-v[version]-linux-x64.tar.xz
 - node-v[version]-win-x64.zip
 
-Sample for Node 10.15.3
+Sample for Node 10.16.0
 
 ```
 jazelle_dependencies(
-  node_version = "10.15.3"
+  node_version = "10.16.0"
   node_sha256 = {
     "mac": "7a5eaa1f69614375a695ccb62017248e5dcc15b0b8edffa7db5b52997cf992ba",
     "linux": "faddbe418064baf2226c2fcbd038c3ef4ae6f936eb952a1138c7ff8cfe862438",

--- a/jazelle/templates/scaffold/WORKSPACE
+++ b/jazelle/templates/scaffold/WORKSPACE
@@ -8,7 +8,7 @@ http_archive(
 
 load("@jazelle//:workspace-rules.bzl", "jazelle_dependencies")
 jazelle_dependencies(
-  node_version = "10.15.3",
+  node_version = "10.16.0",
   node_sha256 = {
     "mac": "7a5eaa1f69614375a695ccb62017248e5dcc15b0b8edffa7db5b52997cf992ba",
     "linux": "faddbe418064baf2226c2fcbd038c3ef4ae6f936eb952a1138c7ff8cfe862438",

--- a/jazelle/tests/fixtures/report-mismatched-top-level-deps/WORKSPACE
+++ b/jazelle/tests/fixtures/report-mismatched-top-level-deps/WORKSPACE
@@ -8,7 +8,7 @@ local_repository(
 
 load("@jazelle//:workspace-rules.bzl", "jazelle_dependencies")
 jazelle_dependencies(
-    node_version = "10.15.3",
+    node_version = "10.16.0",
     node_sha256 = {
         "mac": "7a5eaa1f69614375a695ccb62017248e5dcc15b0b8edffa7db5b52997cf992ba",
         "linux": "faddbe418064baf2226c2fcbd038c3ef4ae6f936eb952a1138c7ff8cfe862438",


### PR DESCRIPTION
Includes additional changes from https://github.com/uber/fusionjs/commit/ffd04f463d144b4ba9b24f6e93be5cd38ebe0f64 that were not mirrored to the public repository.