### PR TITLE
Update executor to handle errors correctly

### DIFF
--- a/fusion-plugin-apollo/src/apollo-client/index.js
+++ b/fusion-plugin-apollo/src/apollo-client/index.js
@@ -90,7 +90,11 @@ const ApolloClientPlugin: FusionPlugin<
     defaultOptions: ApolloClientDefaultOptionsToken.optional,
   },
   provides({
-    getCache = ctx => new InMemoryCache(),
+    getCache = ctx =>
+      // don't automatically add typename when handling POST requests via the executor. This saves size on the response
+      new InMemoryCache({
+        addTypename: ctx.method === 'POST' ? false : true,
+      }),
     endpoint = '/graphql',
     fetch,
     includeCredentials = 'same-origin',

--- a/fusion-plugin-apollo/src/plugin.js
+++ b/fusion-plugin-apollo/src/plugin.js
@@ -126,25 +126,23 @@ export default (renderFn: Render) =>
             }
             return apolloContext;
           },
-          executor: requestContext => {
+          executor: async requestContext => {
             const client = getApolloClient(requestContext.context, {});
-            const args = {
-              variables: requestContext.request.variables,
-              context: requestContext.context,
-            };
-            if (requestContext.operation.operation === 'query') {
-              return client.query({
-                query: requestContext.document,
-                ...args,
+            const queryObservable = client.queryManager.getObservableFromLink(
+              requestContext.document,
+              requestContext.context,
+              requestContext.request.variables
+            );
+            return new Promise((resolve, reject) => {
+              queryObservable.subscribe({
+                next(x) {
+                  resolve(x);
+                },
+                error(err) {
+                  reject(err);
+                },
               });
-            } else if (requestContext.operation.operation === 'mutation') {
-              return client.mutate({
-                mutation: requestContext.document,
-                ...args,
-              });
-            } else {
-              throw new Error('Subscriptions not supported yet');
-            }
+            });
           },
         });
         let serverMiddleware = [];

--- a/fusion-plugin-apollo/src/plugin.js
+++ b/fusion-plugin-apollo/src/plugin.js
@@ -128,6 +128,7 @@ export default (renderFn: Render) =>
           },
           executor: async requestContext => {
             const client = getApolloClient(requestContext.context, {});
+            // $FlowFixMe
             const queryObservable = client.queryManager.getObservableFromLink(
               requestContext.document,
               requestContext.context,


### PR DESCRIPTION
Update executor to handle errors correctly. Also add optimization for only adding __typename when used during an SSR, or from the client.
