### PR TITLE
Fix bugs

### DIFF
--- a/jazelle/bin/cli.sh
+++ b/jazelle/bin/cli.sh
@@ -8,7 +8,7 @@ fi
 
 # find project root
 findroot() {
-  if [ -f "WORKSPACE" ] && grep -v "\"name\": \"jazelle\"" "$PWD/package.json"
+  if [ -f "WORKSPACE" ] && grep -s -v "\"name\": \"jazelle\"" "$PWD/package.json"
   then
     echo "$PWD/"
   elif [ "$PWD" = "/" ]

--- a/jazelle/bin/cli.sh
+++ b/jazelle/bin/cli.sh
@@ -8,7 +8,7 @@ fi
 
 # find project root
 findroot() {
-  if [ -f "WORKSPACE" ]
+  if [ -f "WORKSPACE" ] && grep -v "\"name\": \"jazelle\"" "$PWD/package.json"
   then
     echo "$PWD/"
   elif [ "$PWD" = "/" ]

--- a/jazelle/commands/ci.js
+++ b/jazelle/commands/ci.js
@@ -32,7 +32,7 @@ const ci /*: Ci */ = async ({root, cwd}) => {
   });
   if (!result.valid) throw new Error(getErrorMessage(result));
 
-  await installDeps({root, deps, frozenLockfile: true, hooks});
+  await installDeps({root, deps, hooks});
 };
 
 module.exports = {ci};

--- a/jazelle/commands/install.js
+++ b/jazelle/commands/install.js
@@ -50,9 +50,13 @@ const install /*: Install */ = async ({root, cwd}) => {
   if (!result.valid) throw new Error(getErrorMessage(result));
 
   const downstreams = await findDownstreams({root, deps, projects});
+  const map = {};
+  for (const dep of [...deps, ...downstreams]) {
+    map[dep.meta.name] = dep;
+  }
   await generateDepLockfiles({
     root,
-    deps: [...new Set([...deps, ...downstreams])],
+    deps: Object.keys(map).map(key => map[key]),
   });
   if (workspace === 'sandbox') {
     await generateBazelignore({root, projects: projects});

--- a/jazelle/commands/test.js
+++ b/jazelle/commands/test.js
@@ -1,5 +1,6 @@
 // @flow
 const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {getPassThroughArgs} = require('../utils/parse-argv.js');
 const {getManifest} = require('../utils/get-manifest.js');
 const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
 const bazel = require('../utils/bazel-commands.js');
@@ -9,21 +10,23 @@ const yarn = require('../utils/yarn-commands.js');
 export type TestArgs = {
   root: string,
   cwd: string,
+  args: Array<string>,
 }
 export type Test = (TestArgs) => Promise<void>
 */
-const test /*: Test */ = async ({root, cwd}) => {
+const test /*: Test */ = async ({root, cwd, args}) => {
   await assertProjectDir({dir: cwd});
 
+  const params = getPassThroughArgs(args);
   const {projects, workspace} = await getManifest({root});
   if (workspace === 'sandbox') {
-    await bazel.test({root, cwd});
+    await bazel.test({root, cwd, args: params});
   } else {
     const deps = await getLocalDependencies({
       dirs: projects.map(dir => `${root}/${dir}`),
       target: cwd,
     });
-    await yarn.test({root, deps});
+    await yarn.test({root, deps, args: params});
   }
 };
 

--- a/jazelle/index.js
+++ b/jazelle/index.js
@@ -144,7 +144,7 @@ const runCLI /*: RunCLI */ = async argv => {
         `Test a project
 
         --cwd [cwd]             Project directory to use`,
-        async ({cwd}) => test({root, cwd}),
+        async ({cwd}) => test({root, cwd, args: rest}),
       ],
       lint: [
         `Lint a project

--- a/jazelle/rules/execute-command.js
+++ b/jazelle/rules/execute-command.js
@@ -24,8 +24,9 @@ const binPath = exists(`${main}/node_modules/.bin`)
   ? `:${main}/node_modules/.bin`
   : '';
 const payload = scripts[command] || ``;
+const nodeDir = dirname(node);
 // prioritize hermetic Node version over system version
-const script = `export PATH=${dirname(node)}:$PATH${binPath}; ${payload}`;
+const script = `export PATH=${nodeDir}:$PATH${binPath}; ${payload}`;
 
 if (out) {
   exec(`mkdir -p "${dist}"`, {cwd: main});

--- a/jazelle/tests/index.js
+++ b/jazelle/tests/index.js
@@ -323,6 +323,7 @@ async function testBazelDummy() {
   await bazelCmds.test({
     root: `${__dirname}/tmp/bazel`,
     cwd: `${__dirname}/tmp/bazel`,
+    args: [],
     name: 'target',
     stdio: ['ignore', testStream, 'ignore'],
   });
@@ -365,6 +366,7 @@ async function testBazelBuild() {
   await bazelCmds.test({
     root: `${__dirname}/tmp/bazel-rules`,
     cwd: `${__dirname}/tmp/bazel-rules/projects/a`,
+    args: [],
     name: 'test',
     stdio: ['ignore', testStream, 'ignore'],
   });
@@ -978,6 +980,7 @@ async function testYarnCommands() {
   await yarnCmds.test({
     root,
     deps,
+    args: [],
     stdio: ['ignore', testStream, 'ignore'],
   });
   assert((await read(testStreamFile, 'utf8')).includes('\n444\n'));

--- a/jazelle/utils/bazel-commands.js
+++ b/jazelle/utils/bazel-commands.js
@@ -32,6 +32,7 @@ const build /*: Build */ = async ({
 export type TestArgs = {
   root: string,
   cwd: string,
+  args: Array<string>,
   name?: string,
   stdio?: Stdio,
 };
@@ -40,6 +41,7 @@ type Test = (TestArgs) => Promise<void>;
 const test /*: Test */ = async ({
   root,
   cwd,
+  args,
   name = 'test',
   stdio = 'inherit',
 }) => {

--- a/jazelle/utils/yarn-commands.js
+++ b/jazelle/utils/yarn-commands.js
@@ -75,14 +75,19 @@ const dev /*: Dev */ = async ({root, deps, stdio = 'inherit'}) => {
 export type TestArgs = {
   root: string,
   deps: Array<Metadata>,
+  args: Array<string>,
   stdio?: Stdio,
 };
 export type Test = (TestArgs) => Promise<void>;
 */
-const test /*: Test */ = async ({root, deps, stdio = 'inherit'}) => {
+const test /*: Test */ = async ({root, deps, args, stdio = 'inherit'}) => {
   const main = deps.slice(-1).pop();
   await batchBuild({root, deps, self: false, stdio: errorsOnly});
-  await spawn(node, [yarn, 'test'], {stdio, env: process.env, cwd: main.dir});
+  await spawn(node, [yarn, 'test', ...args], {
+    stdio,
+    env: process.env,
+    cwd: main.dir,
+  });
 };
 
 /*::


### PR DESCRIPTION
- let jazelle run within its own folder in fusion monorepo
- avoid `jazelle ci` false positive nag
- only generate lockfiles once per package regardless of dep graph
- pass cli args to test script in host mode