### PR TITLE
Add dependency crawling to jazelle changes

### DIFF
--- a/jazelle/commands/changes.js
+++ b/jazelle/commands/changes.js
@@ -1,5 +1,8 @@
 // @flow
 const {findChangedTargets} = require('../utils/find-changed-targets.js');
+const {getDownstreams} = require('../utils/get-downstreams.js');
+const {getManifest} = require('../utils/get-manifest.js');
+const {read} = require('../utils/node-helpers.js');
 
 /*::
 type ChangesArgs = {
@@ -11,8 +14,30 @@ type ChangesArgs = {
 type Changes = (ChangesArgs) => Promise<void>;
 */
 const changes /*: Changes */ = async ({root, sha1, sha2, type}) => {
+  // Get every changed target
   const targets = await findChangedTargets({root, sha1, sha2, type});
-  console.log(targets.join('\n'));
+  const changeSet = new Set(targets);
+
+  const {projects} = await getManifest({root});
+  const allProjects = await Promise.all([
+    ...projects.map(async dir => {
+      const meta = JSON.parse(await read(`${root}/${dir}/package.json`, 'utf8'));
+      return {dir, meta, depth: 1};
+    }),
+  ]);
+
+  // Add to the changeSet all downstream packages that have a dependency
+  for (const target of targets) {
+    const dep = allProjects.find(project => project.dir === target);
+    if (dep) {
+      const downstreamDeps = getDownstreams(allProjects, dep);
+      for (const downstreamDep of downstreamDeps) {
+        changeSet.add(downstreamDep.dir);
+      }
+    }
+  }
+
+  console.log(Array.from(changeSet).join('\n'));
 };
 
 module.exports = {changes};

--- a/jazelle/package.json
+++ b/jazelle/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
     "globby": "^10.0.1",
+    "rewire": "^4.0.1",
     "semver": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, jazelle changes only returns the list of projects that were directly altered.

This change adds dependency crawling so that all packages that depend on the changed packages will be returned.

This also adds tests to the changes command that tests this dependency crawling behavior. `rewire` was added in order to stub out the git functionality and to capture stdout for assertions -- otherwise testing would have been extremely difficult. 

I'm open to other approaches though since it looks like jazelle is purposely kept lean if we don't want to introduce this dependency.