### PR TITLE
Add translation-key-missing event

### DIFF
--- a/fusion-plugin-i18n/package.json
+++ b/fusion-plugin-i18n/package.json
@@ -64,6 +64,7 @@
   },
   "peerDependencies": {
     "fusion-core": "0.0.0-monorepo",
+    "fusion-plugin-universal-events": "0.0.0-monorepo",
     "fusion-tokens": "0.0.0-monorepo"
   },
   "engines": {

--- a/fusion-plugin-i18n/src/__tests__/index.browser.js
+++ b/fusion-plugin-i18n/src/__tests__/index.browser.js
@@ -19,15 +19,36 @@ test('hydration', t => {
     chunks: [0],
     translations: {test: 'hello', interpolated: 'hi ${adjective} ${noun}'},
   };
-  t.plan(5);
+  t.plan(8);
   if (!I18n.provides) {
     t.end();
     return;
   }
 
   const mockContext: Context = ({}: any);
-  const i18n = I18n.provides({hydrationState}).from(mockContext);
+  // $FlowFixMe
+  const events = {
+    emit: (name, payload) => {
+      t.equals(
+        name,
+        'i18n-translate-miss',
+        'emits event when translate key missing'
+      );
+      const key = payload && typeof payload === 'object' && payload.key;
+      t.equals(
+        key,
+        'missing-browser-translation',
+        'payload contains key for missing translation'
+      );
+    },
+  };
+
+  const i18n = I18n.provides({hydrationState, events}).from(mockContext);
   t.equals(i18n.translate('test'), 'hello');
+  t.equals(
+    i18n.translate('missing-browser-translation'),
+    'missing-browser-translation'
+  );
   t.equals(
     i18n.translate('interpolated', {adjective: 'big', noun: 'world'}),
     'hi big world'

--- a/fusion-plugin-i18n/src/__tests__/loader.node.js
+++ b/fusion-plugin-i18n/src/__tests__/loader.node.js
@@ -13,6 +13,7 @@ import test from 'tape-cup';
 
 import App from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 import I18n from '../node';
 import createLoader from '../loader';
@@ -24,6 +25,10 @@ test('loader', async t => {
 
   const app = new App('el', el => el);
   app.register(I18nToken, I18n);
+  // $FlowFixMe
+  app.register(UniversalEventsToken, {
+    from: () => ({emit: () => {}}),
+  });
   app.middleware({i18n: I18nToken}, ({i18n}) => {
     return (ctx, next) => {
       const translator = i18n.from(ctx);
@@ -46,6 +51,10 @@ test('custom locale resolver', async t => {
   const app = new App('el', el => el);
   app.register(I18nLoaderToken, createI18nLoader(ctx => 'custom_US'));
   app.register(I18nToken, I18n);
+  // $FlowFixMe
+  app.register(UniversalEventsToken, {
+    from: () => ({emit: () => {}}),
+  });
   app.middleware({i18n: I18nToken}, ({i18n}) => {
     return (ctx, next) => {
       const translator = i18n.from(ctx);

--- a/fusion-plugin-i18n/src/browser.js
+++ b/fusion-plugin-i18n/src/browser.js
@@ -10,6 +10,7 @@
 import {FetchToken} from 'fusion-tokens';
 import {createPlugin, unescape, createToken} from 'fusion-core';
 import type {FusionPlugin, Token} from 'fusion-core';
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 import type {
   I18nDepsType,
@@ -51,8 +52,9 @@ const pluginFactory: () => PluginType = () =>
     deps: {
       fetch: FetchToken.optional,
       hydrationState: HydrationStateToken.optional,
+      events: UniversalEventsToken,
     },
-    provides: ({fetch = window.fetch, hydrationState} = {}) => {
+    provides: ({fetch = window.fetch, hydrationState, events} = {}) => {
       class I18n {
         localeCode: ?string;
         translations: TranslationsObjectType;
@@ -111,13 +113,17 @@ const pluginFactory: () => PluginType = () =>
         }
         translate(key, interpolations = {}) {
           const template = this.translations[key];
-          return template
-            ? template.replace(/\${(.*?)}/g, (_, k) =>
-                interpolations[k] === void 0
-                  ? '${' + k + '}'
-                  : String(interpolations[k])
-              )
-            : key;
+
+          if (typeof template !== 'string') {
+            events && events.emit('i18n-translate-miss', {key});
+            return key;
+          }
+
+          return template.replace(/\${(.*?)}/g, (_, k) =>
+            interpolations[k] === void 0
+              ? '${' + k + '}'
+              : String(interpolations[k])
+          );
         }
       }
       const i18n = new I18n();

--- a/fusion-plugin-i18n/src/types.js
+++ b/fusion-plugin-i18n/src/types.js
@@ -10,11 +10,14 @@ import {Locale} from 'locale';
 
 import {FetchToken} from 'fusion-tokens';
 import type {Context} from 'fusion-core';
+import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 import {HydrationStateToken} from './browser';
 import {I18nLoaderToken} from './tokens.js';
 
 export type TranslationsObjectType = {[string]: string};
+
+type ExtractReturnType = <V>(() => V) => V;
 
 export type TranslateFuncType = (
   key: string,
@@ -25,7 +28,10 @@ export type I18nDepsType = {
   fetch?: typeof FetchToken.optional,
   hydrationState?: typeof HydrationStateToken.optional,
   loader?: typeof I18nLoaderToken.optional,
+  events?: typeof UniversalEventsToken,
 };
+
+export type IEmitter = $Call<ExtractReturnType, typeof UniversalEventsToken>;
 
 export type I18nServiceType = {
   from: (


### PR DESCRIPTION
We have had reports of users intermittently seeing untranslated strings. Adding this event so we can: 
- monitor how frequently this occurs and investigate further if required
- test deploys in canary by alerting on this event