### PR TITLE
Remove --ignore-scripts flag from yarn install command for jazelle

### DIFF
--- a/jazelle/utils/lockfile.js
+++ b/jazelle/utils/lockfile.js
@@ -319,7 +319,7 @@ const update /*: Update */ = async ({
       await write(`${cwd}/package.json`, data, 'utf8');
       const yarnrc = '"--install.frozen-lockfile" false';
       await write(`${cwd}/.yarnrc`, yarnrc, 'utf8');
-      const install = `yarn install --ignore-scripts --ignore-engines`;
+      const install = `yarn install --ignore-engines`;
       await exec(install, {cwd}, [process.stdout, process.stderr]);
 
       // copy newly installed deps back to original package.json/yarn.lock


### PR DESCRIPTION
Removes --ignore-scripts flag from yarn install to support per project pre/postinstall hooks 
