### PR TITLE
Update rush lockfile and fix some lint errors

### DIFF
--- a/jazelle/utils/bazel-commands.js
+++ b/jazelle/utils/bazel-commands.js
@@ -32,7 +32,6 @@ const build /*: Build */ = async ({
 export type TestArgs = {
   root: string,
   cwd: string,
-  args: Array<string>,
   name?: string,
   stdio?: Stdio,
 };
@@ -41,7 +40,6 @@ type Test = (TestArgs) => Promise<void>;
 const test /*: Test */ = async ({
   root,
   cwd,
-  args,
   name = 'test',
   stdio = 'inherit',
 }) => {

--- a/jazelle/utils/yarn-commands.js
+++ b/jazelle/utils/yarn-commands.js
@@ -75,12 +75,12 @@ const dev /*: Dev */ = async ({root, deps, stdio = 'inherit'}) => {
 export type TestArgs = {
   root: string,
   deps: Array<Metadata>,
-  args: Array<string>,
+  args?: Array<string>,
   stdio?: Stdio,
 };
 export type Test = (TestArgs) => Promise<void>;
 */
-const test /*: Test */ = async ({root, deps, args, stdio = 'inherit'}) => {
+const test /*: Test */ = async ({root, deps, args = [], stdio = 'inherit'}) => {
   const main = deps.slice(-1).pop();
   await batchBuild({root, deps, self: false, stdio: errorsOnly});
   await spawn(node, [yarn, 'test', ...args], {


### PR DESCRIPTION
The rush lockfile looks out of date and CI is failing due to a stale lock file.

Some previous PR's introduced new dependencies but it looks like the sync PR was missing some of the changes for some reason. This adds them back manually.