### PR TITLE
Fix typing of optional property in Token

### DIFF
--- a/fusion-core/src/types.js
+++ b/fusion-core/src/types.js
@@ -10,7 +10,7 @@ import type {Context as KoaContext} from 'koa';
 
 export type Token<T> = {
   (): T,
-  optional: () => void | T,
+  optional: Token<void | T>,
   stacks: Array<{
     // eslint-disable-next-line
     type:


### PR DESCRIPTION
In https://github.com/fusionjs/fusionjs/pull/550, we changed the way we extract a Token's underlying service type, but failed to update the 'optional' field which was still using the old way. This PR fixes that by properly applying optionality (but not nullability - super important!) to the underlying type.

I tested this on a fairly large codebase and Flow seemed happy.