### PR TITLE
Ignore all local packages correctly when doing lockfile operations

### DIFF
--- a/jazelle/commands/dedupe.js
+++ b/jazelle/commands/dedupe.js
@@ -3,6 +3,7 @@ const {sync} = require('../utils/lockfile.js');
 const {getManifest} = require('../utils/get-manifest.js');
 const {installDeps} = require('../utils/install-deps.js');
 const {read} = require('../utils/node-helpers.js');
+const {getAllDependencies} = require('../utils/get-all-dependencies.js');
 
 /*::
 export type DedupeArgs = {
@@ -23,7 +24,8 @@ const dedupe /*: Dedupe */ = async ({root}) => {
     ),
     tmp,
   });
-  await installDeps({root});
+  const all = await getAllDependencies({root, projects});
+  await installDeps({root, ignore: all});
 };
 
 module.exports = {dedupe};

--- a/jazelle/commands/greenkeep.js
+++ b/jazelle/commands/greenkeep.js
@@ -3,6 +3,7 @@ const {minVersion, satisfies} = require('semver');
 const {getManifest} = require('../utils/get-manifest.js');
 const {findLocalDependency} = require('../utils/find-local-dependency.js');
 const {upgrade: upgradeDep} = require('../utils/lockfile.js');
+const {getAllDependencies} = require('../utils/get-all-dependencies.js');
 const {generateDepLockfiles} = require('../utils/generate-dep-lockfiles.js');
 const {read, write} = require('../utils/node-helpers.js');
 
@@ -53,13 +54,14 @@ const greenkeep /*: Greenkeep */ = async ({root, name, version, from}) => {
       tmp,
     });
   }
+  const ignore = await getAllDependencies({root, projects});
   const deps = await Promise.all(
     roots.map(async dir => ({
       dir,
       meta: JSON.parse(await read(`${dir}/package.json`, 'utf8')),
     }))
   );
-  await generateDepLockfiles({root, deps});
+  await generateDepLockfiles({root, deps, ignore});
 };
 
 const update = (meta, type, name, version, from) => {

--- a/jazelle/commands/install.js
+++ b/jazelle/commands/install.js
@@ -8,6 +8,7 @@ const {
   getErrorMessage,
 } = require('../utils/report-mismatched-top-level-deps.js');
 const {detectCyclicDeps} = require('../utils/detect-cyclic-deps.js');
+const {getAllDependencies} = require('../utils/get-all-dependencies.js');
 const {generateDepLockfiles} = require('../utils/generate-dep-lockfiles.js');
 const {generateBazelignore} = require('../utils/generate-bazelignore.js');
 const {
@@ -15,7 +16,6 @@ const {
 } = require('../utils/generate-bazel-build-rules.js');
 const {installDeps} = require('../utils/install-deps.js');
 const {getDownstreams} = require('../utils/get-downstreams.js');
-const {read} = require('../utils/node-helpers.js');
 
 /*::
 export type InstallArgs = {
@@ -58,7 +58,11 @@ const install /*: Install */ = async ({root, cwd, frozenLockfile = false}) => {
     );
   }
 
-  const downstreams = await findDownstreams({root, deps, projects});
+  const all = await getAllDependencies({root, projects});
+  const downstreams = [];
+  for (const dep of deps) {
+    downstreams.push(...getDownstreams(all, dep));
+  }
   const map = {};
   for (const dep of [...deps, ...downstreams]) {
     map[dep.meta.name] = dep;
@@ -66,28 +70,14 @@ const install /*: Install */ = async ({root, cwd, frozenLockfile = false}) => {
   await generateDepLockfiles({
     root,
     deps: Object.keys(map).map(key => map[key]),
+    ignore: all,
     frozenLockfile,
   });
   if (workspace === 'sandbox' && frozenLockfile === false) {
     await generateBazelignore({root, projects: projects});
     await generateBazelBuildRules({root, deps, projects});
   }
-  await installDeps({root, deps, hooks});
-};
-
-const findDownstreams = async ({root, deps, projects}) => {
-  const roots = projects.map(dir => `${root}/${dir}`);
-  const metas = await Promise.all(
-    roots.map(async dir => ({
-      dir,
-      meta: JSON.parse(await read(`${dir}/package.json`, 'utf8')),
-    }))
-  );
-  const downstreams = [];
-  for (const dep of deps) {
-    downstreams.push(...getDownstreams(metas, dep));
-  }
-  return downstreams;
+  await installDeps({root, deps, ignore: all, hooks});
 };
 
 module.exports = {install};

--- a/jazelle/tests/index.js
+++ b/jazelle/tests/index.js
@@ -655,6 +655,18 @@ async function testGenerateDepLockfiles() {
         depth: 1,
       },
     ],
+    ignore: [
+      {
+        meta: JSON.parse(
+          await read(
+            `${__dirname}/tmp/generate-dep-lockfiles/a/package.json`,
+            'utf8'
+          )
+        ),
+        dir: `${__dirname}/tmp/generate-dep-lockfiles/a`,
+        depth: 1,
+      },
+    ],
   });
   const lockfile = `${__dirname}/tmp/generate-dep-lockfiles/a/yarn.lock`;
   assert((await read(lockfile, 'utf8')).includes('has@'));
@@ -784,6 +796,22 @@ async function testInstallDeps() {
   const deps = {
     root: `${__dirname}/tmp/install-deps`,
     deps: [
+      {
+        meta: JSON.parse(
+          await read(`${__dirname}/tmp/install-deps/b/package.json`, 'utf8')
+        ),
+        dir: `${__dirname}/tmp/install-deps/b`,
+        depth: 2,
+      },
+      {
+        meta: JSON.parse(
+          await read(`${__dirname}/tmp/install-deps/a/package.json`, 'utf8')
+        ),
+        dir: `${__dirname}/tmp/install-deps/a`,
+        depth: 1,
+      },
+    ],
+    ignore: [
       {
         meta: JSON.parse(
           await read(`${__dirname}/tmp/install-deps/b/package.json`, 'utf8')

--- a/jazelle/utils/generate-dep-lockfiles.js
+++ b/jazelle/utils/generate-dep-lockfiles.js
@@ -7,6 +7,7 @@ import type {Metadata} from './get-local-dependencies.js';
 export type GenerateDepLockfilesArgs = {
   root: string,
   deps: Array<Metadata>,
+  ignore: Array<Metadata>,
   frozenLockfile?: boolean,
 };
 export type GenerateDepLockfiles = (GenerateDepLockfilesArgs) => Promise<void>
@@ -14,13 +15,14 @@ export type GenerateDepLockfiles = (GenerateDepLockfilesArgs) => Promise<void>
 const generateDepLockfiles /*: GenerateDepLockfiles */ = async ({
   root,
   deps,
+  ignore,
   frozenLockfile = false,
 }) => {
   const roots = deps.map(dep => dep.dir);
   const tmp = `${root}/third_party/jazelle/temp/yarn-utilities-tmp`;
   await sync({
     roots,
-    ignore: deps.map(dep => dep.meta.name),
+    ignore: ignore.map(dep => dep.meta.name),
     tmp,
     frozenLockfile,
   });

--- a/jazelle/utils/get-all-dependencies.js
+++ b/jazelle/utils/get-all-dependencies.js
@@ -1,0 +1,28 @@
+// @flow
+const {read} = require('../utils/node-helpers.js');
+
+/*::
+import type {Metadata} from './get-local-dependencies.js';
+
+export type GetAllDependenciesArgs = {
+  root: string,
+  projects: Array<string>,
+};
+export type GetAllDependencies = (GetAllDependenciesArgs) => Promise<Array<Metadata>>;
+*/
+
+const getAllDependencies /*: GetAllDependencies */ = async ({
+  root,
+  projects,
+}) => {
+  const roots = projects.map(dir => `${root}/${dir}`);
+  return Promise.all(
+    roots.map(async dir => ({
+      depth: 0,
+      dir,
+      meta: JSON.parse(await read(`${dir}/package.json`, 'utf8')),
+    }))
+  );
+};
+
+module.exports = {getAllDependencies};

--- a/jazelle/utils/lockfile.js
+++ b/jazelle/utils/lockfile.js
@@ -2,6 +2,7 @@
 const {satisfies, minVersion, validRange, compare, gt} = require('semver');
 const {parse, stringify} = require('@yarnpkg/lockfile');
 const {read, exec, write} = require('./node-helpers.js');
+const {node, yarn} = require('./binary-paths.js');
 
 /*::
 export type Report = {
@@ -334,7 +335,7 @@ const update /*: Update */ = async ({
       await write(`${cwd}/package.json`, data, 'utf8');
       const yarnrc = '"--install.frozen-lockfile" false';
       await write(`${cwd}/.yarnrc`, yarnrc, 'utf8');
-      const install = `yarn install --ignore-scripts --ignore-engines`;
+      const install = `${node} ${yarn} install --ignore-scripts --ignore-engines`;
       await exec(install, {cwd}, [process.stdout, process.stderr]);
 
       // copy newly installed deps back to original package.json/yarn.lock


### PR DESCRIPTION
Currently, lockfile syncing ignores only packages in the direct dep graph, but lockfile syncing also checks downstreams. Transitive deps in downstreams are not ignored, causing yarn to try to install them from the online registry.

Instead, we want to always ignore all local packages when doing lockfile operations