### PR TITLE
Check for null chunkGroup

### DIFF
--- a/fusion-cli/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/fusion-cli/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -288,15 +288,18 @@ function getChunkGroupModules(dep) {
       }
     });
   }
-  dep.block.chunkGroup.chunks.forEach(chunk => {
-    for (const module of chunk.getModules()) {
-      modulesSet.add(getModuleResource(module));
-      if (module instanceof ConcatenatedModule) {
-        module.buildInfo.fileDependencies.forEach(fileDep => {
-          modulesSet.add(fileDep);
-        });
+  const {chunkGroup} = dep.block;
+  if (chunkGroup && Array.isArray(chunkGroup.chunks)) {
+    chunkGroup.chunks.forEach(chunk => {
+      for (const module of chunk.getModules()) {
+        modulesSet.add(getModuleResource(module));
+        if (module instanceof ConcatenatedModule) {
+          module.buildInfo.fileDependencies.forEach(fileDep => {
+            modulesSet.add(fileDep);
+          });
+        }
       }
-    }
-  });
+    });
+  }
   return modulesSet;
 }

--- a/fusion-cli/test/e2e/dynamic-import-orphaned-module/fixture/src/local-dep.js
+++ b/fusion-cli/test/e2e/dynamic-import-orphaned-module/fixture/src/local-dep.js
@@ -1,0 +1,4 @@
+// @noflow
+export default function() {
+  return 'LOCAL-DEP';
+}

--- a/fusion-cli/test/e2e/dynamic-import-orphaned-module/fixture/src/main.js
+++ b/fusion-cli/test/e2e/dynamic-import-orphaned-module/fixture/src/main.js
@@ -1,0 +1,6 @@
+// @noflow
+import localDep from './local-dep.js';
+export default function() {
+  localDep();
+  import('./local-dep.js');
+}

--- a/fusion-cli/test/e2e/dynamic-import-orphaned-module/test.js
+++ b/fusion-cli/test/e2e/dynamic-import-orphaned-module/test.js
@@ -1,0 +1,27 @@
+// @flow
+/* eslint-env node */
+
+const t = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {promisify} = require('util');
+const {cmd} = require('../utils.js');
+
+const readdir = promisify(fs.readdir);
+const dir = path.resolve(__dirname, './fixture');
+
+test('`fusion build` with dynamic imports', async () => {
+  await cmd(`build --dir=${dir}`);
+
+  // Build completes
+  t.ok(true);
+
+  const bundles = await readdir(
+    path.resolve(dir, '.fusion/dist/development/client')
+  );
+
+  const asyncBundles = bundles.filter(f => !/(vendor|runtime|main)/.test(f));
+
+  // No async bundles are created
+  t.equal(asyncBundles.length, 0);
+}, 100000);


### PR DESCRIPTION
Add defensive check of null chunkGroup.

This error surfaced when using the `react-syntax-highlighter` package.

```
TypeError: Cannot read property 'chunks' of undefined
```

Turns out all it needs to be reproduced is to both statically and dynamically import the same module (which `react-syntax-highlighter` does by importing `highlight.js` directly and transitively through `lowlight`).

```js
import fn from './file.js';
export default function() {
  fn();
  import('./file.js');
}
```

The fix is just to check for `dep.block.chunkGroup` before trying to access `chunks`