### PR TITLE
Add peer deps to dev deps for fusion-plugin-i18n and fusion-plugin-rpc

### DIFF
--- a/fusion-plugin-i18n/package.json
+++ b/fusion-plugin-i18n/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react-hooks": "^1.6.1",
     "flow-bin": "^0.102.0",
     "fusion-core": "0.0.0-monorepo",
+    "fusion-plugin-universal-events": "0.0.0-monorepo",
     "fusion-test-utils": "0.0.0-monorepo",
     "fusion-tokens": "0.0.0-monorepo",
     "nyc": "^14.1.0",

--- a/fusion-plugin-rpc/package.json
+++ b/fusion-plugin-rpc/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-react": "^7.14.2",
     "flow-bin": "^0.102.0",
     "fusion-core": "0.0.0-monorepo",
+    "fusion-plugin-i18n": "0.0.0-monorepo",
     "fusion-plugin-universal-events": "0.0.0-monorepo",
     "fusion-test-utils": "0.0.0-monorepo",
     "fusion-tokens": "0.0.0-monorepo",


### PR DESCRIPTION
These peer deps need to be added to dev deps for local installation of the package.