### PR TITLE
Enable symlinks to dist for packages

### DIFF
--- a/jazelle/utils/get-all-dependencies.js
+++ b/jazelle/utils/get-all-dependencies.js
@@ -20,6 +20,7 @@ const getAllDependencies /*: GetAllDependencies */ = async ({
     roots.map(async dir => ({
       depth: 0,
       dir,
+      distDir: undefined,
       meta: JSON.parse(await read(`${dir}/package.json`, 'utf8')),
     }))
   );

--- a/jazelle/utils/get-local-dependencies.js
+++ b/jazelle/utils/get-local-dependencies.js
@@ -1,6 +1,6 @@
 // @flow
 const {satisfies} = require('semver');
-const {read} = require('./node-helpers.js');
+const {read, exists} = require('../utils/node-helpers.js');
 
 /*::
 export type GetLocalDependenciesArgs = {
@@ -10,6 +10,7 @@ export type GetLocalDependenciesArgs = {
 export type GetLocalDependencies = (GetLocalDependenciesArgs) => Promise<Array<Metadata>>;
 export type Metadata = {
   dir: string,
+  distDir: string | void,
   meta: PackageJson,
   depth: number,
 };
@@ -31,7 +32,11 @@ const getLocalDependencies /*: GetLocalDependencies */ = async ({
   const data = await Promise.all([
     ...dirs.map(async dir => {
       const meta = JSON.parse(await read(`${dir}/package.json`, 'utf8'));
-      return {dir, meta, depth: 1};
+      let distDir = undefined;
+      if (await exists(`${dir}/.dist`)) {
+        distDir = `${dir}/.dist`;
+      }
+      return {dir, meta, depth: 1, distDir};
     }),
   ]);
   return unique(findDependencies(data, target));

--- a/jazelle/utils/install-deps.js
+++ b/jazelle/utils/install-deps.js
@@ -97,7 +97,7 @@ const installDeps /*: InstallDeps */ = async ({
       // symlink from global node_modules to local package folders
       if (!(await exists(`${modulesDir}/${dep.meta.name}`))) {
         await spawn('mkdir', ['-p', `${modulesDir}/${ns}`], {cwd: root});
-        await spawn('ln', ['-sf', dep.dir, basename], {
+        await spawn('ln', ['-sf', dep.distDir || dep.dir, basename], {
           cwd: `${modulesDir}/${ns}`,
         });
       }


### PR DESCRIPTION
Creating a PR now here to start the conversation. I'm also not yet confident this is in a working state.

In some cases, we have packages that are compiled in a separate `dist` directory and published from there so that when someone pulls in the package from npm and references a sub file, the import wont contain a reference to `dist`.

````diff
- import foo from 'foo/dist/bar';
+ import foo from 'foo/bar';
````

If we're symlinking these dependencies locally, however, we cannot symlink them in place at the top of the package root. we need instead point the symlink to the dist directory.

This implementation assumes the output `dist` directory is named `.dist` since these files should generally not be committed to source control or visible in the finder.
