### PR TITLE
Fix yarn resolution detection

### DIFF
--- a/jazelle/utils/get-local-dependencies.js
+++ b/jazelle/utils/get-local-dependencies.js
@@ -22,6 +22,7 @@ export type PackageJson = {
   devDependencies?: {[string]: string},
   peerDependencies?: {[string]: string},
   optionalDependencies?: {[string]: string},
+  resolutions?: {[string]: string},
 };
 */
 const getLocalDependencies /*: GetLocalDependencies */ = async ({

--- a/jazelle/utils/is-yarn-resolution.js
+++ b/jazelle/utils/is-yarn-resolution.js
@@ -1,0 +1,19 @@
+// @flow
+
+/*::
+import type {PackageJson} from './get-local-dependencies.js';
+
+type IsYarnResolutionArgs = {
+  meta: PackageJson,
+  name: string,
+}
+type IsYarnResolution = (IsYarnResolutionArgs) => boolean
+*/
+const isYarnResolution /*: IsYarnResolution */ = ({meta, name}) => {
+  return !!Object.keys(meta.resolutions || {}).find(resolution => {
+    const [resolved] = resolution.match(/(@[^/]+\/)?[^@/]+$/) || [];
+    return resolved === name;
+  });
+};
+
+module.exports = {isYarnResolution};


### PR DESCRIPTION
Previous resolution check was too broad and caused false positives
This PR implements a proper resolution check and adds tests to ensure there are no false positives
