### PR TITLE
Add option for skipping prepare

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,11 @@ rush install && rush build
 
 Equivalent: `yarn add lodash`
 
-See: [rush add](https://rushjs.io/pages/commands/rush_add/)
+Currently, using `rush add` is broken with the following error:
 
-```sh
-# --caret: prepend with ^
-# -m: update other packages with this dep
-rush add --caret -m -p lodash
-```
+    ERROR: The Yarn package manager is not currently supported by the "rush add" command.
+
+To work around this, manually update the dependency in the projects `package.json`. Then run `rush update --full --purge`. This may take some time.
 
 ### Upgrade
 

--- a/fusion-react/README.md
+++ b/fusion-react/README.md
@@ -33,6 +33,7 @@ as bundle splitting and `fusion-react` provides tools to do it easily.
   - [prepare](#prepare)
   - [prepared](#prepared)
   - [exclude](#exclude)
+  - [SkipPrepareToken](#skippreparetoken)
   - [Provider - DEPRECATED](#provider)
   - [ProviderPlugin - DEPRECATED](#providerplugin)
   - [ProvidedHOC - DEPRECATED](#providedhoc)
@@ -319,6 +320,16 @@ const NewComponent = exclude(Component);
 - `NewComponent: React.Component` - A component that is excluded from `prepare` traversal.
 
 Stops `prepare` traversal at `Component`. Useful for optimizing the `prepare` traversal to visit the minimum number of nodes.
+
+#### SkipPrepareToken
+
+```js
+import {SkipPrepareToken} from 'fusion-react';
+
+app.register(SkipPrepareToken, true);
+```
+
+Skips the prepare render of the application, which is responsible for running side effects in `prepared` statements.
 
 #### Provider
 

--- a/fusion-react/src/index.js
+++ b/fusion-react/src/index.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import FusionApp, {
+  createToken,
   createPlugin,
   CriticalChunkIdsToken,
   type Context,
@@ -31,6 +32,8 @@ import {
   useService,
   withServices,
 } from './context.js';
+
+export const SkipPrepareToken = createToken<boolean>('SkipPrepareToken');
 
 export type Render = (el: React.Element<*>, context: Context) => any;
 
@@ -57,10 +60,11 @@ export default class App extends FusionApp {
     const renderer = createPlugin({
       deps: {
         criticalChunkIds: CriticalChunkIdsToken.optional,
+        skipPrepare: SkipPrepareToken.optional,
       },
-      provides() {
+      provides({skipPrepare}) {
         return (el: React.Element<*>, ctx) => {
-          return prepare(el).then(() => {
+          return (skipPrepare ? Promise.resolve() : prepare(el)).then(() => {
             if (render) {
               return render(el, ctx);
             }


### PR DESCRIPTION
Adds the SkipPrepareToken which allows configuring the app to skip the prepare render. This is useful in testing, but will also be the default behavior in the future for the browser, as it is no longer needed for handling async components.