### PR TITLE
Fix duplicate translation keys in promise instrumentation

### DIFF
--- a/fusion-cli/build/plugins/instrumented-import-dependency-template-plugin.js
+++ b/fusion-cli/build/plugins/instrumented-import-dependency-template-plugin.js
@@ -53,19 +53,21 @@ class InstrumentedImportDependency extends ImportDependency {
   getInstrumentation() {
     // client-side, use built-in values
     this.chunkIds = getChunkGroupIds(this.block.chunkGroup);
-    this.translationKeys = [];
+    this.translationKeys = new Set();
     if (this.translationsManifest) {
       const modules = getChunkGroupModules(this);
       for (const module of modules) {
         if (this.translationsManifest.has(module)) {
-          const keys = this.translationsManifest.get(module).keys();
-          this.translationKeys.push(...keys);
+          const keys = this.translationsManifest.get(module);
+          for (const key of keys) {
+            this.translationKeys.add(key);
+          }
         }
       }
     }
     return {
       chunkIds: this.chunkIds,
-      translationKeys: this.translationKeys,
+      translationKeys: Array.from(this.translationKeys),
     };
   }
   updateHash(hash) {

--- a/fusion-cli/test/e2e/duplicate-translations/fixture/src/child-component.js
+++ b/fusion-cli/test/e2e/duplicate-translations/fixture/src/child-component.js
@@ -1,0 +1,10 @@
+// @noflow
+
+import React from 'react';
+import {Translate} from 'fusion-plugin-i18n-react';
+
+export default () => (
+  <div>
+    <Translate id="with-child-translation" />
+  </div>
+);

--- a/fusion-cli/test/e2e/duplicate-translations/fixture/src/component-with-children.js
+++ b/fusion-cli/test/e2e/duplicate-translations/fixture/src/component-with-children.js
@@ -1,0 +1,12 @@
+// @noflow
+
+import React from 'react';
+import {Translate} from 'fusion-plugin-i18n-react';
+import ChildComponent from './child-component.js';
+
+export default () => (
+  <div>
+    <Translate id="with-child-translation" />
+    <ChildComponent />
+  </div>
+);

--- a/fusion-cli/test/e2e/duplicate-translations/fixture/src/component.js
+++ b/fusion-cli/test/e2e/duplicate-translations/fixture/src/component.js
@@ -1,0 +1,12 @@
+// @noflow
+
+import React from 'react';
+import {Translate} from 'fusion-plugin-i18n-react';
+
+export default () => (
+  <div>
+    <Translate id="main" />
+    <Translate id="main" />
+    <Translate id="main" />
+  </div>
+);

--- a/fusion-cli/test/e2e/duplicate-translations/fixture/src/main.js
+++ b/fusion-cli/test/e2e/duplicate-translations/fixture/src/main.js
@@ -1,0 +1,24 @@
+// @noflow
+
+import React from 'react';
+import App from 'fusion-react';
+
+function Root () {
+  const main = import('./component.js');
+  const withChild = import('./component-with-children.js');
+  return (
+    <div>
+      <div data-testid="main">
+        {JSON.stringify(main.__I18N_KEYS)}
+      </div>
+      <div data-testid="with-children">
+        {JSON.stringify(withChild.__I18N_KEYS)}
+      </div>
+    </div>
+  );
+}
+
+export default async function start() {
+  const app = new App(<Root />);
+  return app;
+}

--- a/fusion-cli/test/e2e/duplicate-translations/fixture/translations/en-US.json
+++ b/fusion-cli/test/e2e/duplicate-translations/fixture/translations/en-US.json
@@ -1,0 +1,4 @@
+{
+  "main": "__MAIN_TRANSLATED__",
+  "with-child-translation": "__WITH_CHILD_TRANSLATED__"
+}

--- a/fusion-cli/test/e2e/duplicate-translations/test.js
+++ b/fusion-cli/test/e2e/duplicate-translations/test.js
@@ -1,0 +1,40 @@
+// @flow
+/* eslint-env node */
+
+const t = require('assert');
+const path = require('path');
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+const request = require('request-promise');
+
+const dev = require('../setup.js');
+
+const {cmd, start} = require('../utils.js');
+
+const dir = path.resolve(__dirname, './fixture');
+
+test('promise instrumentation deduplicates translations', async () => {
+  var env = Object.create(process.env);
+  env.NODE_ENV = 'production';
+
+  await cmd(`build --dir=${dir}`, {env});
+
+  const {proc, port} = await start(`--dir=${dir}`, {env, cwd: dir});
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/`, {waitUntil: 'load'});
+  const content = await page.content();
+
+  t.ok(
+    content.includes('<div data-testid="main">["main"]</div>'),
+    'translation keys within the same component are de-duped'
+  );
+  t.ok(
+    content.includes('<div data-testid="with-children">["with-child-translation"]</div>'),
+    'translation keys within the same chunk are de-duped'
+  );
+  browser.close();
+  proc.kill();
+}, 100000);

--- a/fusion-cli/test/e2e/duplicate-translations/test.js
+++ b/fusion-cli/test/e2e/duplicate-translations/test.js
@@ -3,11 +3,7 @@
 
 const t = require('assert');
 const path = require('path');
-const fs = require('fs');
 const puppeteer = require('puppeteer');
-const request = require('request-promise');
-
-const dev = require('../setup.js');
 
 const {cmd, start} = require('../utils.js');
 
@@ -32,7 +28,9 @@ test('promise instrumentation deduplicates translations', async () => {
     'translation keys within the same component are de-duped'
   );
   t.ok(
-    content.includes('<div data-testid="with-children">["with-child-translation"]</div>'),
+    content.includes(
+      '<div data-testid="with-children">["with-child-translation"]</div>'
+    ),
     'translation keys within the same chunk are de-duped'
   );
   browser.close();


### PR DESCRIPTION
If the same translation key was used in multiple files within the same chunk, the translation keys would appear multiple times in the translation instrumentation. This is just minor cleanup - doesn't really affect anything other than debugging and sending duplicate keys over the wire.