### PR TITLE
Move translation keys to POST body

### DIFF
--- a/fusion-plugin-i18n/package.json
+++ b/fusion-plugin-i18n/package.json
@@ -38,6 +38,7 @@
     "flow": "flow check"
   },
   "dependencies": {
+    "koa-bodyparser": "^4.2.1",
     "locale": "^0.1.0",
     "rollup": "^0.67.3"
   },

--- a/fusion-plugin-i18n/src/__tests__/index.browser.js
+++ b/fusion-plugin-i18n/src/__tests__/index.browser.js
@@ -145,11 +145,8 @@ test('load', t => {
   };
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   const fetch: any = (url, options) => {
-    t.equals(
-      url,
-      '/_translations?keys=["test-key"]&localeCode=es-MX',
-      'url is ok'
-    );
+    t.equals(url, '/_translations?localeCode=es-MX', 'url is ok');
+    t.equals(options.body, '["test-key"]');
     t.equals(options && options.method, 'POST', 'method is ok');
     t.equals(
       options && options.headers && options.headers['X-Fusion-Locale-Code'],

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -169,6 +169,43 @@ test('endpoint', async t => {
   t.end();
 });
 
+test('endpoint request handles empty body', async t => {
+  const data = {test: 'hello', interpolated: 'hi ${value}'};
+
+  const ctx: Context = {
+    set: () => {},
+    syncChunks: [],
+    preloadChunks: [],
+    headers: {'accept-language': 'en_US'},
+    path: '/_translations',
+    querystring: '',
+    memoized: new Map(),
+    body: void 0,
+  };
+
+  const deps = {
+    loader: {from: () => ({translations: data, locale: 'en-US'})},
+  };
+
+  t.plan(1);
+
+  if (!I18n.provides) {
+    t.end();
+    return;
+  }
+  const i18n = I18n.provides(deps);
+
+  if (!I18n.middleware) {
+    t.end();
+    return;
+  }
+  await I18n.middleware(deps, i18n)(ctx, () => Promise.resolve());
+  t.pass("doesn't throw");
+  t.equals(ctx.body, {}, 'defaults to an empty set of translations');
+
+  t.end();
+});
+
 test('non matched route', async t => {
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   // $FlowFixMe - Invalid context

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -137,7 +137,8 @@ test('endpoint', async t => {
     path: '/_translations',
     querystring: '',
     memoized: new Map(),
-    body: JSON.stringify(['test', 'interpolated']),
+    request: {body: ['test', 'interpolated']},
+    body: '',
   };
 
   const deps = {
@@ -171,7 +172,7 @@ test('endpoint', async t => {
 
 test('endpoint request handles empty body', async t => {
   const data = {test: 'hello', interpolated: 'hi ${value}'};
-
+  // $FlowFixMe - Invalid context
   const ctx: Context = {
     set: () => {},
     syncChunks: [],
@@ -180,7 +181,8 @@ test('endpoint request handles empty body', async t => {
     path: '/_translations',
     querystring: '',
     memoized: new Map(),
-    body: void 0,
+    request: {body: void 0},
+    body: '',
   };
 
   const deps = {

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -187,7 +187,7 @@ test('endpoint request handles empty body', async t => {
     loader: {from: () => ({translations: data, locale: 'en-US'})},
   };
 
-  t.plan(1);
+  t.plan(2);
 
   if (!I18n.provides) {
     t.end();
@@ -201,7 +201,7 @@ test('endpoint request handles empty body', async t => {
   }
   await I18n.middleware(deps, i18n)(ctx, () => Promise.resolve());
   t.pass("doesn't throw");
-  t.equals(ctx.body, {}, 'defaults to an empty set of translations');
+  t.deepEquals(ctx.body, {}, 'defaults to an empty set of translations');
 
   t.end();
 });

--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -135,9 +135,9 @@ test('endpoint', async t => {
     preloadChunks: [],
     headers: {'accept-language': 'en_US'},
     path: '/_translations',
-    querystring: 'keys=["test","interpolated"]',
+    querystring: '',
     memoized: new Map(),
-    body: '',
+    body: JSON.stringify(['test', 'interpolated']),
   };
 
   const deps = {

--- a/fusion-plugin-i18n/src/browser.js
+++ b/fusion-plugin-i18n/src/browser.js
@@ -85,6 +85,7 @@ const pluginFactory: () => PluginType = () =>
               method: 'POST',
               headers: {
                 Accept: '*/*',
+                'Content-Type': 'application/json',
                 ...(this.locale ? {'X-Fusion-Locale-Code': this.locale} : {}),
               },
               body: JSON.stringify(unloaded),

--- a/fusion-plugin-i18n/src/browser.js
+++ b/fusion-plugin-i18n/src/browser.js
@@ -74,14 +74,6 @@ const pluginFactory: () => PluginType = () =>
           const unloaded = translationKeys.filter(key => {
             return loadedKeys.indexOf(key) < 0 && !this.requestedKeys.has(key);
           });
-          const fetchOpts = {
-            method: 'POST',
-            headers: {
-              Accept: '*/*',
-              ...(this.locale ? {'X-Fusion-Locale-Code': this.locale} : {}),
-            },
-          };
-          const localeParam = this.locale ? `&localeCode=${this.locale}` : '';
           if (unloaded.length > 0) {
             // Don't try to load translations again if a request is already in
             // flight. This means that we need to add unloaded chunks to
@@ -89,9 +81,19 @@ const pluginFactory: () => PluginType = () =>
             unloaded.forEach(key => {
               this.requestedKeys.add(key);
             });
+            const fetchOpts = {
+              method: 'POST',
+              headers: {
+                Accept: '*/*',
+                ...(this.locale ? {'X-Fusion-Locale-Code': this.locale} : {}),
+              },
+              body: JSON.stringify(unloaded),
+            };
             // TODO(#3) don't append prefix if injected fetch also injects prefix
             return fetch(
-              `/_translations?keys=${JSON.stringify(unloaded)}${localeParam}`,
+              `/_translations${
+                this.locale ? `?localeCode=${this.locale}` : ''
+              }`,
               fetchOpts
             )
               .then(r => r.json())

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -8,7 +8,6 @@
 
 /* eslint-env node */
 
-import querystring from 'querystring';
 import {Locale} from 'locale';
 
 import {createPlugin, memoize, html} from 'fusion-core';
@@ -160,9 +159,7 @@ const pluginFactory: () => PluginType = () =>
           ctx.template.htmlAttrs['lang'] = localeCode;
         } else if (ctx.path === '/_translations') {
           const i18n = plugin.from(ctx);
-          const keys = JSON.parse(
-            querystring.parse(ctx.querystring).keys || '[]'
-          );
+          const keys = JSON.parse(ctx.body) || [];
           const possibleTranslations = i18n.translations
             ? Object.keys(i18n.translations)
             : [];

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -159,7 +159,7 @@ const pluginFactory: () => PluginType = () =>
           ctx.template.htmlAttrs['lang'] = localeCode;
         } else if (ctx.path === '/_translations') {
           const i18n = plugin.from(ctx);
-          const keys = JSON.parse(ctx.body) || [];
+          const keys = JSON.parse(ctx.body || '[]');
           const possibleTranslations = i18n.translations
             ? Object.keys(i18n.translations)
             : [];


### PR DESCRIPTION
When using dynamic translations in split components, some translations requests can exceed the max http header size for node. Move translation keys to POST body to fix this