### PR TITLE
Allow isolation of dep installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We initially [built Fusion.js](https://eng.uber.com/fusionjs/) to make our own w
 
 If you're interested in giving Fusion a shot, [Getting started](https://fusionjs.com/docs/getting-started/) and [Core concepts](https://fusionjs.com/docs/learn-fusion/core-concepts) are great places to start.
 
+
 ## Contributing
 
 This is a monorepo of all open source Fusion.js packages maintained using [rushjs](https://rushjs.io/). Take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for info on how to develop in this repo.

--- a/jazelle/bin/cli.sh
+++ b/jazelle/bin/cli.sh
@@ -40,7 +40,7 @@ then
   # if we're in a repo, jazelle declaration in WORKSPACE is wrong, so we should error out
   if [ -f "$ROOT/WORKSPACE" ]
   then
-    echo "Error: Invalid \`jazelle\` declaration in WORKSPACE file"
+    echo "Error: Invalid \`jazelle\` configuration in WORKSPACE file. Check the Jazelle download URL and the checksums for Node and Yarn"
     exit 1
   fi
   if [ ! -f "$BIN/yarn.js" ]

--- a/jazelle/commands/dedupe.js
+++ b/jazelle/commands/dedupe.js
@@ -1,9 +1,7 @@
 // @flow
 const {sync} = require('../utils/lockfile.js');
 const {getManifest} = require('../utils/get-manifest.js');
-const {installDeps} = require('../utils/install-deps.js');
 const {read} = require('../utils/node-helpers.js');
-const {getAllDependencies} = require('../utils/get-all-dependencies.js');
 
 /*::
 export type DedupeArgs = {
@@ -24,8 +22,6 @@ const dedupe /*: Dedupe */ = async ({root}) => {
     ),
     tmp,
   });
-  const all = await getAllDependencies({root, projects});
-  await installDeps({root, ignore: all});
 };
 
 module.exports = {dedupe};

--- a/jazelle/commands/install.js
+++ b/jazelle/commands/install.js
@@ -77,7 +77,8 @@ const install /*: Install */ = async ({root, cwd, frozenLockfile = false}) => {
     await generateBazelignore({root, projects: projects});
     await generateBazelBuildRules({root, deps, projects});
   }
-  await installDeps({root, deps, ignore: all, hooks});
+  const modulesDir = `${root}/node_modules`;
+  await installDeps({root, cwd, modulesDir, deps, ignore: all, hooks});
 };
 
 module.exports = {install};

--- a/jazelle/rules/jazelle.bzl
+++ b/jazelle/rules/jazelle.bzl
@@ -5,7 +5,7 @@ def _jazelle_impl(ctx):
     export YARN=$(cd `dirname "{yarn}"` && pwd)/$(basename {yarn})
     NODE=$(cd `dirname "{node}"` && pwd)/$(basename {node})
     CLI=$(cd `dirname "{cli}"` && pwd)/$(basename {cli})
-    CWD=`{node} -e "console.log(require('path').dirname(require('fs').realpathSync('{manifest}')))"`
+    CWD=`$NODE -e "console.log(require('path').dirname(require('fs').realpathSync('{manifest}')))"`
     cd $CWD && $NODE $CLI $@
     """.format(
       node = ctx.files._node[0].path,

--- a/jazelle/tests/index.js
+++ b/jazelle/tests/index.js
@@ -812,6 +812,8 @@ async function testInstallDeps() {
   await exec(cmd);
   const deps = {
     root: `${__dirname}/tmp/install-deps`,
+    cwd: `${__dirname}/tmp/install-deps/a`,
+    modulesDir: `${__dirname}/tmp/install-deps/node_modules`,
     deps: [
       {
         meta: JSON.parse(

--- a/jazelle/utils/install-deps.js
+++ b/jazelle/utils/install-deps.js
@@ -88,47 +88,47 @@ const installDeps /*: InstallDeps */ = async ({
   if (modulesDir) {
     await spawn('rm', ['-rf', modulesDir], {cwd: root});
     await spawn('mv', [`${bin}/node_modules`, modulesDir], {cwd: root});
-  }
 
-  // symlink local deps
-  await Promise.all(
-    deps.map(async dep => {
-      const [ns, basename] = dep.meta.name.startsWith('@')
-        ? dep.meta.name.split('/')
-        : ['.', dep.meta.name];
-      // symlink from global node_modules to local package folders
-      if (!(await exists(`${modulesDir}/${dep.meta.name}`))) {
-        await spawn('mkdir', ['-p', `${modulesDir}/${ns}`], {cwd: root});
-        await spawn('ln', ['-sf', dep.dir, basename], {
-          cwd: `${modulesDir}/${ns}`,
-        });
-      }
-
-      // symlink node_modules/.bin from local packages to global .bin
-      if (!(await exists(`${dep.dir}/node_modules/.bin`))) {
-        await spawn('mkdir', ['-p', 'node_modules'], {cwd: dep.dir});
-        await spawn('ln', ['-sf', `${modulesDir}/.bin`, '.bin'], {
-          cwd: `${dep.dir}/node_modules`,
-        });
-      }
-
-      // symlink from global node_modules/.bin to local bin scripts
-      const bin =
-        typeof dep.meta.bin === 'string'
-          ? {[dep.meta.name]: dep.meta.bin}
-          : dep.meta.bin;
-      if (!(await exists(`${modulesDir}/.bin`))) {
-        await spawn('mkdir', ['-p', `${modulesDir}/.bin`], {cwd: root});
-      }
-      for (const cmd in bin) {
-        if (!(await exists(`${modulesDir}/.bin/${cmd}`))) {
-          await spawn('ln', ['-sf', `${dep.dir}/${bin[cmd]}`, cmd], {
-            cwd: `${modulesDir}/.bin`,
+    // symlink local deps
+    await Promise.all(
+      deps.map(async dep => {
+        const [ns, basename] = dep.meta.name.startsWith('@')
+          ? dep.meta.name.split('/')
+          : ['.', dep.meta.name];
+        // symlink from global node_modules to local package folders
+        if (!(await exists(`${modulesDir}/${dep.meta.name}`))) {
+          await spawn('mkdir', ['-p', `${modulesDir}/${ns}`], {cwd: root});
+          await spawn('ln', ['-sf', dep.dir, basename], {
+            cwd: `${modulesDir}/${ns}`,
           });
         }
-      }
-    })
-  );
+
+        // symlink node_modules/.bin from local packages to global .bin
+        if (!(await exists(`${dep.dir}/node_modules/.bin`))) {
+          await spawn('mkdir', ['-p', 'node_modules'], {cwd: dep.dir});
+          await spawn('ln', ['-sf', `${modulesDir}/.bin`, '.bin'], {
+            cwd: `${dep.dir}/node_modules`,
+          });
+        }
+
+        // symlink from global node_modules/.bin to local bin scripts
+        const bin =
+          typeof dep.meta.bin === 'string'
+            ? {[dep.meta.name]: dep.meta.bin}
+            : dep.meta.bin;
+        if (!(await exists(`${modulesDir}/.bin`))) {
+          await spawn('mkdir', ['-p', `${modulesDir}/.bin`], {cwd: root});
+        }
+        for (const cmd in bin) {
+          if (!(await exists(`${modulesDir}/.bin/${cmd}`))) {
+            await spawn('ln', ['-sf', `${dep.dir}/${bin[cmd]}`, cmd], {
+              cwd: `${modulesDir}/.bin`,
+            });
+          }
+        }
+      })
+    );
+  }
 
   // package postinstall hook
   for (const dep of deps) {

--- a/jazelle/utils/lockfile.js
+++ b/jazelle/utils/lockfile.js
@@ -421,11 +421,13 @@ const update /*: Update */ = async ({
       const oldKeys = Object.keys(item.lockfile);
       const newKeys = Object.keys(lockfile);
       if (oldKeys.sort().join() !== newKeys.sort().join()) {
-        throw new Error(
+        console.error(
           `Updating lockfile is not allowed with frozenLockfile. ` +
             `This error is most likely happening if you have committed ` +
             `out-of-date lockfiles and tried to install deps in CI. ` +
-            `Install your deps again locally.`
+            `Install your deps again locally.\n\n` +
+            `OLD: ${oldKeys.sort().join()}\n\n` +
+            `NEW: ${newKeys.sort().join()}`
         );
       }
     } else {


### PR DESCRIPTION
Allow isolation of dep installations so multiple node_modules can be generated at the same time

This is plumbing required to make it possible to run multiple node_modules installations in parallel in a single machine (for CI parallelization)