### PR TITLE
Remove browserHistory preservation logic across jsdom browser tests

### DIFF
--- a/fusion-plugin-react-router/src/plugin.js
+++ b/fusion-plugin-react-router/src/plugin.js
@@ -142,10 +142,16 @@ const plugin: FusionPlugin<PluginDepsType, HistoryWrapperType> = createPlugin({
             }
             return payload;
           });
-        // Expose the history object
-        if (!browserHistory) {
+        // preserving browser history across hmr fixes warning "Warning: You cannot change <Router history>"
+        // we don't want to preserve the `browserHistory` instance across jsdom tests however, as it will cause
+        // routes to match based on the previous location information.
+        if (
+          !browserHistory ||
+          (__DEV__ && typeof window.jsdom !== 'undefined')
+        ) {
           browserHistory = createBrowserHistory({basename: ctx.prefix});
         }
+        // Expose the history object
         myAPI.history = browserHistory;
         ctx.element = (
           <Router


### PR DESCRIPTION
We need to preserve browser history across hmr to resolve the warning "Warning: You cannot change <Router history>". See https://github.com/fusionjs/fusion-plugin-react-router/pull/239

However, we don't want to preserve the `browserHistory` instance across jsdom tests however, as it will cause routes to match based on the previous location information. This adds logic in a `__DEV__` block to check for if the app is running a jsdom test, and removes the preservation logic in that case.