### PR TITLE
Fix styled font faces [fusion-plugin-font-loader-react] 

### DIFF
--- a/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
+++ b/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
@@ -37,9 +37,9 @@ export const atomicFontFaces = `
   @font-face{font-family:"Lato-Thin";font-display:fallback;src:url("Lato-Thin.woff")format("woff"),url("Lato-Thin.woff2")format("woff2");}`;
 
 export const styledFontFaces = `
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Regular.woff") format("woff"), url("Lato-Regular.woff2") format("woff2"); font-weight: 400;}
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Bold.woff") format("woff"), url("Lato-Bold.woff2") format("woff2"); font-weight:600;}
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Thin.woff") format("woff"), url("Lato-Thin.woff2") format("woff2"); font-weight:200;}`;
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Regular.woff") format("woff"), url("Lato-Regular.woff2") format("woff2"); font-weight: 400; fontStyle: 'normal';}
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Bold.woff") format("woff"), url("Lato-Bold.woff2") format("woff2"); font-weight:600; fontStyle: 'normal';}
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Thin.woff") format("woff"), url("Lato-Thin.woff2") format("woff2"); font-weight:200; fontStyle: 'normal';}`;
 
 export const preloadLinks =
   '\n<link rel="preload" href="Lato-Regular.woff2" as="font" type="font/woff2" crossorigin>';

--- a/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
+++ b/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
@@ -9,24 +9,24 @@
 export const fallbackLookup = {
   depth0: {},
   depth1: {
-    "Lato-Bold": {
-      name: "Lato-Regular",
-      styles: { fontWeight: "bold" },
+    'Lato-Bold': {
+      name: 'Lato-Regular',
+      styles: {fontWeight: 'bold'},
     },
-    "Lato-Thin": {
-      name: "Lato-Regular",
-      styles: { fontWeight: "100" },
+    'Lato-Thin': {
+      name: 'Lato-Regular',
+      styles: {fontWeight: '100'},
     },
   },
   depth2: {
-    "Lato-Regular": {
-      name: "Helvetica",
+    'Lato-Regular': {
+      name: 'Helvetica',
     },
-    "Lato-Bold": {
-      name: "Helvetica",
+    'Lato-Bold': {
+      name: 'Helvetica',
     },
-    "Lato-Thin": {
-      name: "Helvetica",
+    'Lato-Thin': {
+      name: 'Helvetica',
     },
   },
 };

--- a/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
+++ b/fusion-plugin-font-loader-react/src/__tests__/fixtures/expected.js
@@ -9,24 +9,24 @@
 export const fallbackLookup = {
   depth0: {},
   depth1: {
-    'Lato-Bold': {
-      name: 'Lato-Regular',
-      styles: {fontWeight: 'bold'},
+    "Lato-Bold": {
+      name: "Lato-Regular",
+      styles: { fontWeight: "bold" },
     },
-    'Lato-Thin': {
-      name: 'Lato-Regular',
-      styles: {fontWeight: '100'},
+    "Lato-Thin": {
+      name: "Lato-Regular",
+      styles: { fontWeight: "100" },
     },
   },
   depth2: {
-    'Lato-Regular': {
-      name: 'Helvetica',
+    "Lato-Regular": {
+      name: "Helvetica",
     },
-    'Lato-Bold': {
-      name: 'Helvetica',
+    "Lato-Bold": {
+      name: "Helvetica",
     },
-    'Lato-Thin': {
-      name: 'Helvetica',
+    "Lato-Thin": {
+      name: "Helvetica",
     },
   },
 };
@@ -37,9 +37,9 @@ export const atomicFontFaces = `
   @font-face{font-family:"Lato-Thin";font-display:fallback;src:url("Lato-Thin.woff")format("woff"),url("Lato-Thin.woff2")format("woff2");}`;
 
 export const styledFontFaces = `
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Regular.woff") format("woff"), url("Lato-Regular.woff2") format("woff2"); font-weight: 400; fontStyle: 'normal';}
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Bold.woff") format("woff"), url("Lato-Bold.woff2") format("woff2"); font-weight:600; fontStyle: 'normal';}
-  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Thin.woff") format("woff"), url("Lato-Thin.woff2") format("woff2"); font-weight:200; fontStyle: 'normal';}`;
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Regular.woff") format("woff"), url("Lato-Regular.woff2") format("woff2"); font-weight: 400; font-style: normal;}
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Bold.woff") format("woff"), url("Lato-Bold.woff2") format("woff2"); font-weight:600; font-style: normal;}
+  @font-face {font-family: "Lato"; font-display: fallback; src: url("Lato-Thin.woff") format("woff"), url("Lato-Thin.woff2") format("woff2"); font-weight:200; font-style: normal;}`;
 
 export const preloadLinks =
   '\n<link rel="preload" href="Lato-Regular.woff2" as="font" type="font/woff2" crossorigin>';

--- a/fusion-plugin-font-loader-react/src/__tests__/fixtures/static/font-config.js
+++ b/fusion-plugin-font-loader-react/src/__tests__/fixtures/static/font-config.js
@@ -68,6 +68,7 @@ const styledFonts: StyledFontsObjectType = {
       },
       styles: {
         fontWeight: 400,
+        fontStyle: 'normal',
       },
     },
     {
@@ -77,6 +78,7 @@ const styledFonts: StyledFontsObjectType = {
       },
       styles: {
         fontWeight: 600,
+        fontStyle: 'normal',
       },
     },
     {
@@ -86,6 +88,7 @@ const styledFonts: StyledFontsObjectType = {
       },
       styles: {
         fontWeight: 200,
+        fontStyle: 'normal',
       },
     },
   ],

--- a/fusion-plugin-font-loader-react/src/generate-font-faces.js
+++ b/fusion-plugin-font-loader-react/src/generate-font-faces.js
@@ -35,7 +35,7 @@ export function generateStyledFontFaces(fonts: StyledFontsObjectType) {
 font-family: "${fontName}";
 font-display: fallback;
 src: ${asFontFaceSrc(fontInstance.urls).join(',\n')};
-${String(asFontFaceStyles(fontInstance.styles))}}`
+${asFontFaceStyles(fontInstance.styles).join('')}}`
       );
     });
   });
@@ -49,8 +49,6 @@ function asFontFaceSrc(urls) {
   );
 }
 
-function asFontFaceStyles(styles) {
-  return styles
-    ? Object.keys(styles).map(key => `${toKebabCase(key)}: ${styles[key]};\n`)
-    : '';
+function asFontFaceStyles(styles = {}) {
+  return Object.keys(styles).map(key => `${toKebabCase(key)}: ${styles[key]};\n`);
 }

--- a/fusion-plugin-font-loader-react/src/generate-font-faces.js
+++ b/fusion-plugin-font-loader-react/src/generate-font-faces.js
@@ -50,5 +50,7 @@ function asFontFaceSrc(urls) {
 }
 
 function asFontFaceStyles(styles = {}) {
-  return Object.keys(styles).map(key => `${toKebabCase(key)}: ${styles[key]};\n`);
+  return Object.keys(styles).map(
+    key => `${toKebabCase(key)}: ${styles[key]};\n`
+  );
 }


### PR DESCRIPTION
**fusion-plugin-font-loader-react** plugin

While using this plugin in styled mode it's not possible to add more than one style due to a wrong parsing - additional comma is added and the styles are not read properly by the browser, e.g.
```
 fontWeight: 600;
 ,fontStyle: 'normal';
```

This is a fix for that.


