### PR TITLE
Handle legacy query params in translations requests

### DIFF
--- a/fusion-plugin-i18n/src/__tests__/index.node.js
+++ b/fusion-plugin-i18n/src/__tests__/index.node.js
@@ -208,6 +208,44 @@ test('endpoint request handles empty body', async t => {
   t.end();
 });
 
+test('endpoint request handles legacy query params', async t => {
+  const data = {test: 'hello', interpolated: 'hi ${value}'};
+  // $FlowFixMe - Invalid context
+  const ctx: Context = {
+    set: () => {},
+    syncChunks: [],
+    preloadChunks: [],
+    headers: {'accept-language': 'en_US'},
+    path: '/_translations',
+    querystring: 'keys=["test","interpolated"]',
+    memoized: new Map(),
+    request: {body: void 0},
+    body: '',
+  };
+
+  const deps = {
+    loader: {from: () => ({translations: data, locale: 'en-US'})},
+  };
+
+  t.plan(2);
+
+  if (!I18n.provides) {
+    t.end();
+    return;
+  }
+  const i18n = I18n.provides(deps);
+
+  if (!I18n.middleware) {
+    t.end();
+    return;
+  }
+  await I18n.middleware(deps, i18n)(ctx, () => Promise.resolve());
+  t.pass("doesn't throw");
+  t.deepEquals(ctx.body, {}, 'defaults to an empty set of translations');
+
+  t.end();
+});
+
 test('non matched route', async t => {
   const data = {test: 'hello', interpolated: 'hi ${value}'};
   // $FlowFixMe - Invalid context

--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -14,6 +14,7 @@ import {createPlugin, memoize, html} from 'fusion-core';
 import type {FusionPlugin} from 'fusion-core';
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import bodyparser from 'koa-bodyparser';
+import querystring from 'querystring';
 
 import {I18nLoaderToken} from './tokens.js';
 import createLoader from './loader.js';
@@ -166,7 +167,9 @@ const pluginFactory: () => PluginType = () =>
           } catch (e) {
             ctx.request.body = [];
           }
-          const keys = ctx.request.body || [];
+          const keys = ctx.request.body || JSON.parse(
+            querystring.parse(ctx.querystring).keys || '[]'
+          ) || [];
           const possibleTranslations = i18n.translations
             ? Object.keys(i18n.translations)
             : [];


### PR DESCRIPTION
Requests with the legacy query params will cause an uncaught exception:

`TypeError: keys.reduce is not a function
    at /home/udocker/web-eats-v2/node_modules/fusion-plugin-i18n/dist/index.js:216:35
    at process._tickCallback (internal/process/next_tick.js:68:7)`

In order for gradual rollouts we need to still handle the legacy requests from clients that are older than the server.