### PR TITLE
Issue #548 Add an ability to register multiple redux stores in a single application

### DIFF
--- a/fusion-plugin-react-redux/src/index.js
+++ b/fusion-plugin-react-redux/src/index.js
@@ -19,4 +19,5 @@ export {
   PreloadedStateToken,
   EnhancerToken,
   GetInitialStateToken,
+  ReducerNameSpaceToken,
 } from './tokens';

--- a/fusion-plugin-react-redux/src/tokens.js
+++ b/fusion-plugin-react-redux/src/tokens.js
@@ -26,3 +26,6 @@ export const EnhancerToken: Token<StoreEnhancer<*, *, *>> = createToken(
 export const GetInitialStateToken: Token<GetInitialStateType<*>> = createToken(
   'GetInitialStateToken'
 );
+export const ReducerNameSpaceToken: Token<string> = createToken(
+  'ReducerNameSpaceToken'
+);

--- a/fusion-plugin-react-redux/src/types.js
+++ b/fusion-plugin-react-redux/src/types.js
@@ -15,6 +15,7 @@ import {
   PreloadedStateToken,
   EnhancerToken,
   GetInitialStateToken,
+  ReducerNameSpaceToken,
 } from './tokens.js';
 
 export type GetInitialStateType<TState> = (
@@ -24,6 +25,7 @@ export type GetInitialStateType<TState> = (
 export type StoreWithContextType<S, A, D> = Store<S, A, D> & {ctx: Context};
 
 export type ReactReduxDepsType = {
+  namespace: typeof ReducerNameSpaceToken.optional,
   reducer: typeof ReducerToken,
   preloadedState: typeof PreloadedStateToken.optional,
   enhancer: typeof EnhancerToken.optional,

--- a/fusion-plugin-react-redux/src/utils.js
+++ b/fusion-plugin-react-redux/src/utils.js
@@ -1,0 +1,18 @@
+/** Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export const parseNamespace = (
+  namespace?: ?string
+): {suffix: string, cacheKey: string} => {
+  const suffix = namespace !== undefined && namespace !== null ? namespace : '';
+  const cacheKey =
+    namespace !== undefined && namespace !== null
+      ? namespace.toString()
+      : 'default';
+  return {suffix, cacheKey};
+};


### PR DESCRIPTION
Add an ability to register multiple redux stores in a single application

ReducerNameSpaceToken allows separating redux store cache by the unique key.
This allows creating multiple redux stores per application instance, as well as multiple fusion apps with different redux stores