### PR TITLE
Fix translate interpolations parameter type to be read-only

### DIFF
--- a/fusion-plugin-i18n/src/types.js
+++ b/fusion-plugin-i18n/src/types.js
@@ -21,7 +21,7 @@ type ExtractReturnType = <V>(() => V) => V;
 
 export type TranslateFuncType = (
   key: string,
-  interpolations?: {[string]: string | number}
+  interpolations?: {+[string]: string | number}
 ) => string;
 
 export type I18nDepsType = {


### PR DESCRIPTION
this allows us to pass in {[string]: string} and {[string]: number} as arguments without flow complaining

closes issue #701 