### PR TITLE
Fix this.translations === null in translate function

### DIFF
--- a/fusion-plugin-i18n/src/node.js
+++ b/fusion-plugin-i18n/src/node.js
@@ -105,7 +105,7 @@ const pluginFactory: () => PluginType = () =>
         }
         async load() {} //mirror client API
         translate(key, interpolations = {}) {
-          const template = this.translations[key];
+          const template = this.translations ? this.translations[key] : null;
 
           if (typeof template !== 'string') {
             this.emitter && this.emitter.emit('i18n-translate-miss', {key});
@@ -115,7 +115,7 @@ const pluginFactory: () => PluginType = () =>
           return template.replace(/\${(.*?)}/g, (_, k) =>
             interpolations[k] === void 0
               ? '${' + k + '}'
-              : String(interpolations[k])
+              : String(interpolations[k]),
           );
         }
       }
@@ -145,12 +145,12 @@ const pluginFactory: () => PluginType = () =>
             : [];
           chunks.forEach(id => {
             const keys = Array.from(
-              chunkTranslationMap.translationsForChunk(id)
+              chunkTranslationMap.translationsForChunk(id),
             );
             keys.forEach(key => {
               if (Array.isArray(key)) {
                 const matches = possibleTranslations.filter(
-                  matchesLiteralSections(key)
+                  matchesLiteralSections(key),
                 );
                 for (const match of matches) {
                   translations[match] =
@@ -192,7 +192,7 @@ const pluginFactory: () => PluginType = () =>
           const translations = keys.reduce((acc, key) => {
             if (Array.isArray(key)) {
               const matches = possibleTranslations.filter(
-                matchesLiteralSections(key)
+                matchesLiteralSections(key),
               );
               for (const match of matches) {
                 acc[match] = i18n.translations && i18n.translations[match];


### PR DESCRIPTION
I encountered this === null type error in one of the service.

```
TypeError: Cannot read property 'app.title' of undefined\n    at I18n.translate (/home/udocker/safety-lens/node_modules/fusion-plugin-i18n/src/node.js:47:28
```

This happens in SSR

The app was migrated from bedrock and don't know if my config messed it up but wanted to prevent this from happening even with the wrong config

This happens when we don't provide any other language translations other than English and users set browser locale to different languages.

I was expecting it to fallback to English automatically but it seems it's not the case.