### PR TITLE
Update Link to "Getting Started" - the page longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We initially [built Fusion.js](https://eng.uber.com/fusionjs/) to make our own w
 
 ## Try it out
 
-If you're interested in giving Fusion.js a shot, [Getting started](https://fusionjs.com/docs/getting-started/) and [Core concepts](https://fusionjs.com/docs/learn-fusion/core-concepts) are great places to start.
+If you're interested in giving Fusion.js a shot, [Overview](https://fusionjs.com/docs/overview/) and [Core concepts](https://fusionjs.com/docs/learn-fusion/core-concepts) are great places to start.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We initially [built Fusion.js](https://eng.uber.com/fusionjs/) to make our own w
 
 ## Try it out
 
-If you're interested in giving Fusion.js a shot, [Overview](https://fusionjs.com/docs/overview/) and [Core concepts](https://fusionjs.com/docs/learn-fusion/core-concepts) are great places to start.
+If you're interested in giving Fusion.js a shot, [Overview](https://fusionjs.com/docs/overview/) and [Core Concepts](https://fusionjs.com/docs/core-concepts/) are great places to start.
 
 
 ## Contributing


### PR DESCRIPTION
Hi friends! Just a tiny fix to the readme, as the link `/docs/getting-started` path no longer exists
Edit: Made a second commit because I realized "core concepts" url didn't work either. I assume the docs routes were refactored but forgot to be updated in the readme 📝 📜 I also title cased "Core Concepts" (instead of lowercase "concepts")