### PR TITLE
Update README.md

### DIFF
--- a/eslint-config-fusion/README.md
+++ b/eslint-config-fusion/README.md
@@ -11,7 +11,7 @@ Extend `eslint-config-fusion` in your `.eslintrc.js`:
 ```js
 module.exports = {
   extends: [
-    require.resolve('eslint-config-fusion')
+    'fusion'
   ]
 };
 ```


### PR DESCRIPTION
Based on the shareable configs doc we don't need resolve.require to include fusion linting rules. We also don't need "eslint-config-" because the system assumes that.

"You can also omit the eslint-config- and it will be automatically assumed by ESLint:"

https://eslint.org/docs/developer-guide/shareable-configs