### PR TITLE
Update index.js

### DIFF
--- a/eslint-config-fusion/index.js
+++ b/eslint-config-fusion/index.js
@@ -1,7 +1,6 @@
 // @flow
 module.exports = {
   extends: [
-    'plugin:flowtype/recommended',
     'plugin:react/recommended',
     'plugin:jest/recommended',
     './rules/imports.js',
@@ -10,30 +9,18 @@ module.exports = {
   ],
 
   plugins: [
-    'eslint-plugin-flowtype',
     'eslint-plugin-react',
     'eslint-plugin-react-hooks',
   ],
   rules: {
-    // Enforce flow file declarations
-    'flowtype/require-valid-file-annotation': ['error', 'always'],
-
     // We should be using flow rather than propTypes
     'react/prop-types': 'off',
-
-    // Enforces consistent spacing within generic type annotation parameters.
-    // https://github.com/gajus/eslint-plugin-flowtype/blob/master/.README/rules/generic-spacing.md
-    'flowtype/generic-spacing': 'off',
 
     // Enforce hook rules
     // https://reactjs.org/docs/hooks-faq.html#what-exactly-do-the-lint-rules-enforce
     'react-hooks/rules-of-hooks': 'error',
     // https://github.com/facebook/react/issues/14920
     'react-hooks/exhaustive-deps': 'warn',
-
-    // Fix inconsistency between Flow (inherited rule from flowtype/recommended) and Prettier
-    // https://jeng.uberinternal.com/browse/WPT-3404
-    'flowtype/space-after-type-colon': 'off',
 
     'require-atomic-updates': 0,
   },


### PR DESCRIPTION
Flowtype rules shouldn't be included in the Fusion eslint rules because Fusion can be run on systems that don't include flowtype, such as Typescript. Requiring these rules would force projects to install eslint-plugin-flowtype even though they don't need it to run Fusion. Those projects would then have to include the following to disable flowtype linting errors:

```
rules: {
    "flowtype/require-valid-file-annotation": 0,
    "flowtype/no-types-missing-file-annotation": 0,
```

A recommendation is to split flowtype and typescript rules into their own packages, such as eslint-config-fusion-flowtype and eslint-config-fusion-typescript. The users of Fusion can choose which package to install, or the scaffolding tool can select the appropriate package depending on the type of project (if that choice becomes available in the future).