### PR TITLE
Update flowtype for prepared

### DIFF
--- a/fusion-react/src/async/prepared.js
+++ b/fusion-react/src/async/prepared.js
@@ -19,7 +19,7 @@ type PreparedOpts = {
 };
 
 const prepared = (
-  sideEffect: (any, any) => Promise<any>,
+  sideEffect: (any, any) => any | Promise<any>,
   opts?: PreparedOpts = {}
 ) => <Config>(
   OriginalComponent: React.ComponentType<Config>


### PR DESCRIPTION
`sideEffect` doesn't actually need to return a Promise since it is wrapped once in Promise.resolve and the other two times the return type is discarded.