### PR TITLE
Add `no-console` eslint rule

### DIFF
--- a/eslint-config-fusion/rules/imports.js
+++ b/eslint-config-fusion/rules/imports.js
@@ -160,5 +160,8 @@ module.exports = {
     // eslint-config-jest@23 adds these rules that are incompatible with `fusion-test-utils`
     'jest/expect-expect': 'off',
     'jest/no-test-callback': 'off',
+
+    // Disallow the use of `console`
+    'no-console': 'error',
   },
 };


### PR DESCRIPTION
I imagine There Will Be Discussion about the value of adding / not adding this rule. IMO, it's a valuable safeguard against committing debugging statements, and is easy to disable line-by-line for necessary `console` usage.

Also, it seems that [`eslint-config-uber-base`](https://github.com/uber-web/uber-eslint/blob/master/packages/eslint-config-uber-base/index.js) might be a better place for this, but @rtsao suggested I start with a PR to Fusion.

