### PR TITLE
Refactor fusion-plugin-react-router to make depending on browser history easier

### DIFF
--- a/fusion-plugin-react-router/README.md
+++ b/fusion-plugin-react-router/README.md
@@ -174,6 +174,23 @@ app.register(GetStaticContextToken, (ctx: Context) => {
 });
 ```
 
+##### `BrowserHistoryToken`
+
+```js
+import {BrowserHistoryToken} from 'fusion-plugin-react-router';
+```
+
+Token for exposing the browser's history to providers. See "Accessing History" below for more.
+
+
+##### `browserHistoryPlugin`
+
+```jsx
+import {browserHistoryPlugin} from 'fusion-plugin-react-router';
+```
+
+Plugin for exposing the browser's history to providers. See "Accessing History" below for more.
+
 ---
 
 #### Routing Events and Timing Metrics
@@ -219,6 +236,26 @@ app.register(createPlugin({
   }
 }));
 ```
+
+Alternatively, you can access the history on the browser using `BrowserHistoryToken` and `browserHistoryPlugin`.
+
+```js
+import {createPlugin} from 'fusion-core';
+import {BrowserHistoryToken, browserHistoryPlugin} from 'fusion-plugin-react-router';
+
+app.register(BrowserHistoryToken, browserHistoryPlugin);
+app.register(createPlugin({
+  deps: {
+    history: BrowserHistoryToken
+  },
+  provides: ({history}) => {
+    // ...
+  }
+}))
+```
+
+This is useful if you want to get the browser's history within a provider.
+
 
 #### Router
 

--- a/fusion-plugin-react-router/src/index.js
+++ b/fusion-plugin-react-router/src/index.js
@@ -10,6 +10,8 @@ import plugin, {
   RouterProviderToken,
   RouterToken,
   GetStaticContextToken,
+  BrowserHistoryToken,
+  browserHistoryPlugin,
 } from './plugin';
 import * as server from './server';
 import * as browser from './browser';
@@ -20,7 +22,13 @@ declare var __BROWSER__: Boolean;
 
 export default plugin;
 
-export {RouterProviderToken, RouterToken, GetStaticContextToken};
+export {
+  RouterProviderToken,
+  RouterToken,
+  GetStaticContextToken,
+  BrowserHistoryToken,
+  browserHistoryPlugin,
+};
 
 export const BrowserRouter = __BROWSER__
   ? browser.BrowserRouter


### PR DESCRIPTION
Remaking fusionjs/fusionjs#738 which was improperly merged

---

Hello!

I'm creating this PR to follow up on a conversation I had with @ganemone.

tl;dr– I'd like to be able to access browser history in a provider of one of my plugins. Being able to access history in a provider saves me from writing a lot of boilerplate downstream, which greatly simplifies my application and plugin code.

I'm curious if the approach below is something that makes sense– ~~I pulled apart the router plugin into distinct server and browser plugins, and then I have just the browser plugin depend on the router history.~~

Thanks in advance!