### PR TITLE
Fix issue #745 [fusion-plugin-react-router] uncaught URIError

### DIFF
--- a/fusion-plugin-react-router/__tests__/plugin.js
+++ b/fusion-plugin-react-router/__tests__/plugin.js
@@ -139,6 +139,25 @@ if (__NODE__) {
     expect(ctx.res.getHeader('Location')).toBe('/test/lol');
     cleanup();
   });
+  test('handles url with invalid URI encoding', async () => {
+    const Hello = () => <div>Hello</div>;
+    const element = (
+      <div>
+        <Route path="/" component={Hello} />
+      </div>
+    );
+    const app = getApp(element);
+    const UniversalEvents = getMockEvents({
+      title: 'no-matching-route',
+      page: '/%C0%AE%C0%AE/',
+    });
+    app.register(UniversalEventsToken, UniversalEvents);
+    const simulator = setup(app);
+    const ctx = await simulator.render('/%C0%AE%C0%AE/');
+
+    expect(ctx.response.status).toBe(200);
+    cleanup();
+  });
 }
 
 test('events with trackingId', async () => {
@@ -213,7 +232,7 @@ test('Custom Provider', async () => {
 
   const app = getApp(element);
   const UniversalEvents = getMockEvents({
-    title: '/',
+    title: 'no-matching-route',
     page: '/',
   });
   app.register(UniversalEventsToken, UniversalEvents);
@@ -438,6 +457,29 @@ if (__BROWSER__) {
     app.register(UniversalEventsToken, UniversalEvents);
     const simulator = setup(app);
     await simulator.render('/');
+  });
+  test('handles url with invalid URI encoding', async () => {
+    const Hello = () => <div>Hello</div>;
+    const element = (
+      <div>
+        <Route path="/" component={Hello} />
+      </div>
+    );
+    const app = getApp(element);
+    const UniversalEvents = getMockEvents({
+      title: 'no-matching-route',
+      page: '/%C0%AE%C0%AE/',
+    });
+    app.register(UniversalEventsToken, UniversalEvents);
+    const simulator = setup(app);
+    const ctx = await simulator.render('/%C0%AE%C0%AE/');
+
+    const node = document.getElementById('root');
+    if (!node || !node.textContent) {
+      throw new Error('Could not find node.');
+    }
+    expect(node && node.textContent).toBe('Hello');
+    cleanup();
   });
 }
 

--- a/fusion-plugin-react-router/__tests__/plugin.js
+++ b/fusion-plugin-react-router/__tests__/plugin.js
@@ -472,7 +472,7 @@ if (__BROWSER__) {
     });
     app.register(UniversalEventsToken, UniversalEvents);
     const simulator = setup(app);
-    const ctx = await simulator.render('/%C0%AE%C0%AE/');
+    await simulator.render('/%C0%AE%C0%AE/');
 
     const node = document.getElementById('root');
     if (!node || !node.textContent) {

--- a/fusion-plugin-react-router/__tests__/plugin.js
+++ b/fusion-plugin-react-router/__tests__/plugin.js
@@ -139,7 +139,7 @@ if (__NODE__) {
     expect(ctx.res.getHeader('Location')).toBe('/test/lol');
     cleanup();
   });
-  test('handles url with invalid URI encoding', async () => {
+  test('handles url with invalid URI encoding on server', async () => {
     const Hello = () => <div>Hello</div>;
     const element = (
       <div>
@@ -458,7 +458,7 @@ if (__BROWSER__) {
     const simulator = setup(app);
     await simulator.render('/');
   });
-  test('handles url with invalid URI encoding', async () => {
+  test('handles url with invalid URI encoding in browser', async () => {
     const Hello = () => <div>Hello</div>;
     const element = (
       <div>

--- a/fusion-plugin-react-router/src/modules/ServerHistory.js
+++ b/fusion-plugin-react-router/src/modules/ServerHistory.js
@@ -21,7 +21,22 @@ const createLocation = (
   prefix: string
 ): LocationType => {
   const unprefixed = removeRoutePrefix(path, prefix);
-  return defaultCreateLocation(unprefixed);
+  try {
+    return defaultCreateLocation(unprefixed);
+  } catch (e) {
+    if (e instanceof URIError) {
+      return defaultCreateLocation(
+        typeof unprefixed === 'string'
+          ? encodeURI(unprefixed)
+          : {
+              ...unprefixed,
+              pathname: encodeURI(unprefixed.pathname),
+            }
+      );
+    } else {
+      throw e;
+    }
+  }
 };
 
 const createPrefixedURL = (


### PR DESCRIPTION
fixes issue fusionjs/fusionjs#745 

in ServerHistory, we currently use history.createLocation which attempts to decodeURI the pathname

this throws errors when given a pathname with invalid uri encoding such as /%C0%AE%C0%AE/

previously, we were using parsePath without the decoding so this seems like a regression

the fix is to catch the invalid decoding error and simply encode the pathname beforehand, nullifying the decodeURI step.