### PR TITLE
add reduxDevtoolsConfig token to customize setup of Redux devtools extension

### DIFF
--- a/fusion-plugin-react-redux/src/browser.js
+++ b/fusion-plugin-react-redux/src/browser.js
@@ -18,7 +18,12 @@ import type {Context, FusionPlugin} from 'fusion-core';
 
 import ctxEnhancer from './ctx-enhancer';
 import {deserialize} from './codec.js';
-import {ReducerToken, PreloadedStateToken, EnhancerToken} from './tokens.js';
+import {
+  ReducerToken,
+  PreloadedStateToken,
+  EnhancerToken,
+  ReduxDevtoolsConfigToken,
+} from './tokens.js';
 import type {
   StoreWithContextType,
   ReactReduxDepsType,
@@ -32,8 +37,9 @@ const getPlugin = () => {
       reducer: ReducerToken,
       preloadedState: PreloadedStateToken.optional,
       enhancer: EnhancerToken.optional,
+      reduxDevToolsConfig: ReduxDevtoolsConfigToken.optional,
     },
-    provides({reducer, preloadedState, enhancer}) {
+    provides({reducer, preloadedState, enhancer, reduxDevToolsConfig}) {
       class Redux {
         store: StoreWithContextType<*, *, *>;
 
@@ -53,10 +59,17 @@ const getPlugin = () => {
               }
             }
             const devTool =
+              reduxDevToolsConfig !== false &&
               __DEV__ &&
               window.__REDUX_DEVTOOLS_EXTENSION__ &&
               // $FlowFixMe
-              __REDUX_DEVTOOLS_EXTENSION__({trace: true, traceLimit: 25});
+              __REDUX_DEVTOOLS_EXTENSION__({
+                trace: true,
+                traceLimit: 25,
+                ...((typeof reduxDevToolsConfig === 'object' &&
+                  reduxDevToolsConfig) ||
+                  {}),
+              });
             const enhancers = [enhancer, ctxEnhancer(ctx), devTool].filter(
               Boolean
             );

--- a/fusion-plugin-react-redux/src/tokens.js
+++ b/fusion-plugin-react-redux/src/tokens.js
@@ -23,6 +23,9 @@ export const PreloadedStateToken: Token<Object> = createToken(
 export const EnhancerToken: Token<StoreEnhancer<*, *, *>> = createToken(
   'EnhancerToken'
 );
+export const ReduxDevtoolsConfigToken: Token<{} | false> = createToken(
+  'ReduxDevtoolsConfigToken'
+);
 export const GetInitialStateToken: Token<GetInitialStateType<*>> = createToken(
   'GetInitialStateToken'
 );


### PR DESCRIPTION
Some applications need to configure the behavior of Redux Devtools Extension. Allow customization of opting out of the setup altogether.

Resolves WPT-6128