### PR TITLE
Finish flush when we return, when there are no items to push

### DIFF
--- a/fusion-plugin-universal-events/__tests__/test.browser.js
+++ b/fusion-plugin-universal-events/__tests__/test.browser.js
@@ -174,6 +174,21 @@ test('Respects the limit when flushing', async () => {
   emitter.teardown();
 });
 
+test('Calling flush even no items works as expected', async () => {
+  store.getAndClear();
+  const fetch: Fetch = () => Promise.resolve(createMockFetch());
+  const emitter = new UniversalEmitter(fetch, store, 100, 20);
+  await emitter.flush();
+  await emitter.flush();
+  await new Promise(resolve => setTimeout(resolve, 3000));
+  for (let index = 0; index < 20; index++) {
+    emitter.emit('a', {x: 1});
+  }
+  await emitter.flush();
+  expect(store.data.length).toBe(0);
+  emitter.teardown();
+});
+
 test('Lowers limit for 413 errors', async () => {
   store.getAndClear();
   const fetch: Fetch = () =>

--- a/fusion-plugin-universal-events/src/browser.js
+++ b/fusion-plugin-universal-events/src/browser.js
@@ -69,7 +69,10 @@ export class UniversalEmitter extends Emitter {
     const items = this.storage.getAndClear(this.limit);
     this.storage.addToStart(...items);
 
-    if (items.length === 0) return;
+    if (items.length === 0) {
+      this.finishFlush();
+      return;
+    }
     try {
       const res = await this.fetch('/_events', {
         method: 'POST',


### PR DESCRIPTION
If we don't have any items to push the condition is triggered and we return. If we don't call finishFlush() looks like flushInternal would always be blocked.