### PR TITLE
feat(fusion-cli): add graceful shutdown to start command

### DIFF
--- a/fusion-cli-tests/test/e2e/dynamic-import-app/test.js
+++ b/fusion-cli-tests/test/e2e/dynamic-import-app/test.js
@@ -259,7 +259,8 @@ test('`fusion build` app with Safari user agent and same-origin', async () => {
   await cmd(`build --dir=${dir} --production`, {env});
 
   // Run puppeteer test to ensure that page loads with dynamic content.
-  const {proc, port} = await start(`--dir=${dir}`, {env});
+  const {proc, port, promise} = await start(`--dir=${dir}`, {env});
+  promise.catch(console.error);
 
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],

--- a/fusion-cli-tests/test/e2e/utils.js
+++ b/fusion-cli-tests/test/e2e/utils.js
@@ -66,10 +66,11 @@ function cmd(args /*: any */, options /*: any */) {
 
 async function start(args /*: any */, options /*: any */) {
   const port = await getPort();
+  const promise = cmd(`start --port=${port} ${args}`, options);
   // $FlowFixMe
-  const {proc} = cmd(`start --port=${port} ${args}`, options);
+  const {proc} = promise;
   const res = await waitForServer(port);
-  return {proc, res, port};
+  return {proc, res, port, promise};
 }
 
 async function dev(args /*: any */, options /*: any */) {


### PR DESCRIPTION
This PR proposes to add signal handling to the `$ fusion start` command. This solves 2 issues:

1) In a docker container the nodejs process is PID 1 which causes the `fusion start` command to not stop on SIGINT or SIGTERM. This will make sure fusion actually listens and respects these signals.
2) `fusion start` will gracefully exit and allows open connections to finish