### PR TITLE
Update fusion-plugin-csrf-protection plugin to include the route prefix for non-csrf method requests

### DIFF
--- a/fusion-plugin-csrf-protection/src/browser.js
+++ b/fusion-plugin-csrf-protection/src/browser.js
@@ -16,7 +16,7 @@ const enhancer = (fetch: Fetch) => {
     if (!options) options = {};
     const isCsrfMethod = verifyMethod(options.method || 'GET');
     if (!isCsrfMethod) {
-      return fetch(url, options);
+      return fetch(prefix + String(url), options);
     }
     return fetch(prefix + String(url), {
       ...options,


### PR DESCRIPTION
Add the route prefix to URL for non-csrf method requests like GET requests