### PR TITLE
Add more event handlers for page leave in fusion-plugin-universal-events

### DIFF
--- a/fusion-plugin-universal-events/__tests__/test.browser.js
+++ b/fusion-plugin-universal-events/__tests__/test.browser.js
@@ -71,7 +71,7 @@ test('Browser EventEmitter', async () => {
         emitted = true;
       });
       emitter.emit('a', {x: 1});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -128,7 +128,7 @@ test('Browser EventEmitter - should fall back to fetch if sendBeacon is not supp
         emitted = true;
       });
       emitter.emit('a', {x: 1});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -154,7 +154,7 @@ test('Browser EventEmitter - should fall back to fetch if beacon fails to enqueu
       const emitter = events.from(ctx);
       expect(emitter).toBe(events);
       emitter.emit('a', {x: 1});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -178,7 +178,7 @@ test('Browser EventEmitter - should not send all the events if beacon is too big
       expect(emitter).toBe(events);
       emitter.emit('a', {x: 'a'.repeat(40000)});
       emitter.emit('b', {x: 'b'.repeat(40000)});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -200,7 +200,7 @@ test('Browser EventEmitter - fetch adds events back to queue if they fail to sen
       const emitter = events.from(ctx);
       expect(emitter).toBe(events);
       emitter.emit('a', {x: 1});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -221,7 +221,7 @@ test('Browser EventEmitter - fetch adds events back to queue if they fail to sen
       const emitter = events.from(ctx);
       expect(emitter).toBe(events);
       emitter.emit('a', {x: 1});
-      window.dispatchEvent(visibilitychangeEvent);
+      document.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };

--- a/fusion-plugin-universal-events/src/browser.js
+++ b/fusion-plugin-universal-events/src/browser.js
@@ -50,7 +50,9 @@ export class UniversalEmitter extends Emitter {
     this.fetch = fetch;
     this.setFrequency(interval);
     this.limit = limit;
-    window.addEventListener('visibilitychange', this.flushBeforeTerminated);
+    document.addEventListener('visibilitychange', this.flushBeforeTerminated);
+    window.addEventListener('pagehide', this.flush);
+    window.addEventListener('beforeunload', this.flush);
   }
   setFrequency(frequency: number): void {
     window.clearInterval(this.interval);
@@ -102,6 +104,10 @@ export class UniversalEmitter extends Emitter {
       // $FlowFixMe already checked navigator.sendBeacon existence
       if (navigator.sendBeacon('/_events', payload)) {
         this.storage.getAndClear(itemsToSend.length);
+        // Do not start a new flush if current payload is big because the next beacon would be rejected.
+        if (items.length !== itemsToSend.length) {
+          this.hasFlushBeenScheduled = false;
+        }
         this.finishFlush();
         return;
       }
@@ -134,7 +140,9 @@ export class UniversalEmitter extends Emitter {
     }
   }
   teardown(): void {
-    window.removeEventListener('visibilitychange', this.flushBeforeTerminated);
+    document.removeEventListener('visibilitychange', this.flushBeforeTerminated);
+    window.removeEventListener('pagehide', this.flush);
+    window.removeEventListener('beforeunload', this.flush);
     clearInterval(this.interval);
     this.interval = null;
   }


### PR DESCRIPTION
`visibilitychange` event does not work well on some browsers ([link](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event)), so add event handlers for `pagehide`
and `beforeunload` events too. Do not add event handler for `unload` event because on some browsers
it disables `back/forward-caching` ([link](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event)).
Add event listener for `visibilitychange` on `document` as `EventTarget` instead of `window` because
it works better on some old versions of Safari ([link](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event)).
Interesting article about this [here](https://nicj.net/beaconing-in-practice/).