### PR TITLE
Remove deprecated `browser` field from jest configs

### DIFF
--- a/fusion-cli/build/jest/jsdom/jest.config.js
+++ b/fusion-cli/build/jest/jsdom/jest.config.js
@@ -14,7 +14,6 @@ module.exports = {
   ...baseJestConfig,
   resolver: require.resolve('../resolver.js'),
   displayName: 'browser',
-  browser: true,
   name: 'browser',
   // Exposes global.jsdom so we can reconfigure the url on each simulator.render call
   testEnvironment: 'jest-environment-jsdom-global',

--- a/fusion-cli/build/jest/node/jest.config.js
+++ b/fusion-cli/build/jest/node/jest.config.js
@@ -14,7 +14,6 @@ module.exports = {
   ...baseJestConfig,
   resolver: require.resolve('../resolver.js'),
   displayName: 'node',
-  browser: false,
   name: 'node',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['.*\\.browser\\.[jt]sx?'],


### PR DESCRIPTION
This field has been deprecated and is causing every invocation of `fusion test` to produce the following error:

```
● Deprecation Warning:

  Option "browser" has been deprecated. Please install "browser-resolve" and use the "resolver" option in Jest configuration as follows:
  {
    "resolver": "browser-resolve"
  }


  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

● Deprecation Warning:

  Option "browser" has been deprecated. Please install "browser-resolve" and use the "resolver" option in Jest configuration as follows:
  {
    "resolver": "browser-resolve"
  }


  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```