### PR TITLE
Nit pick but remove extra map in middleware function

### DIFF
--- a/fusion-core/src/utils/wrap-middleware.js
+++ b/fusion-core/src/utils/wrap-middleware.js
@@ -17,8 +17,7 @@ const getSources = (stacks) => {
         .split('\n')
         .map((line) => line.match(/\((.*?)\)/))
         .filter((match) => match && match[1])
-        .map((match) => match[1])
-        .map((to) => (__NODE__ ? path.relative(process.cwd(), to) : to))
+        .map((match) => (__NODE__ ? path.relative(process.cwd(), match[1]) : match[1]))
         .shift(),
     };
   });


### PR DESCRIPTION
Nit picking but I think we can get away without the extra map?