### PR TITLE
Add support for TypeScript sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ bazel-*
 !.yarn/sdks
 !.yarn/versions
 yarn.lock
+
+# typescript
+*.tsbuildinfo

--- a/eslint-config-fusion/package.json
+++ b/eslint-config-fusion/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-react-hooks": "^4.1.0",
     "flow-bin": "0.131.0",
     "jest": "^28.1.3",
-    "prettier": "^2.3.0"
+    "prettier": "^2.5.1"
   },
   "engines": {
     "node": ">=8.9.4",

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/__snapshots__/index.test.js.snap
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`withPlugin errors: .using without invocation 1`] = `
-"unknown: withPlugin must be invoked
+"unknown file: withPlugin must be invoked
   1 |
   2 |     import {withPlugin} from \\"fusion-core\\";
 > 3 |     withPlugin.using(TokenA, TokenB);
@@ -10,7 +10,7 @@ exports[`withPlugin errors: .using without invocation 1`] = `
 `;
 
 exports[`withPlugin errors: bare 1`] = `
-"unknown: withPlugin must be invoked
+"unknown file: withPlugin must be invoked
   1 |
   2 |     import {withPlugin} from \\"fusion-core\\";
 > 3 |     withPlugin;
@@ -19,7 +19,7 @@ exports[`withPlugin errors: bare 1`] = `
 `;
 
 exports[`withPlugin errors: property 1`] = `
-"unknown: withPlugin must be invoked
+"unknown file: withPlugin must be invoked
   1 |
   2 |     import {withPlugin} from \\"fusion-core\\";
 > 3 |     withPlugin.someProperty;

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/arrow-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/arrow-expected
@@ -1,9 +1,7 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
 import { withDeps } from "fusion-core";
-
 function getPlugin() {
   var _this = this;
-
   return /*#__PURE__*/_declarePlugin(function* () {
     console.log(_this);
     const [a] = yield withDeps([A]);

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/collision-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/collision-expected
@@ -1,14 +1,11 @@
 import { declarePlugin as _declarePlugin2 } from "fusion-core";
-
 var MyPluginA = /*#__PURE__*/_declarePlugin2(function* MyPluginA() {
   const [a] = yield withDeps([A]);
   return a;
 });
-
 var MyPluginB = /*#__PURE__*/_declarePlugin2(function* MyPluginB() {
   const [b] = yield withDeps([B]);
   return b;
 });
-
 import { withDeps } from "fusion-core";
 const _declarePlugin = "collision";

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/environment-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/environment-expected
@@ -1,11 +1,8 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
-
 var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
   __NODE__ ? withEndpoint("/foo", handler) : void 0;
 });
-
 var RawPlugin = /*#__PURE__*/_declarePlugin(function* RawPlugin() {
   __NODE__ ? withEndpoint("/foo", handler) : void 0;
 });
-
 import { withEndpoint } from "fusion-core";

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/multiple-hooks-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/multiple-hooks-expected
@@ -1,9 +1,7 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
-
 var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
   const [a] = yield withDeps([A]);
   withRenderSetup();
   return a;
 });
-
 import { withDeps, withRenderSetup } from "fusion-core";

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/nested-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/nested-expected
@@ -1,5 +1,4 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
-
 var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
   return yield withPlugin( /*#__PURE__*/_declarePlugin(function* () {
     return yield withPlugin(() => {
@@ -7,5 +6,4 @@ var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
     });
   }));
 });
-
 import { withPlugin } from "fusion-core";

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/raw-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/raw-expected
@@ -1,8 +1,6 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
-
 var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
   const [a] = yield withDeps([A]);
   __NODE__ ? withEndpoint("/foo", handler) : void 0;
 });
-
 import { withDeps } from "fusion-core";

--- a/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/withplugin-expected
+++ b/fusion-cli/build/babel-plugins/babel-plugin-functional-plugin-syntax/test/fixtures/withplugin-expected
@@ -1,9 +1,7 @@
 import { declarePlugin as _declarePlugin } from "fusion-core";
-
 var MyPlugin = /*#__PURE__*/_declarePlugin(function* MyPlugin() {
   const foo = yield withPlugin(FooPlugin);
   const bar = yield withPlugin.using(TokenA, a)(BarPlugin);
   const baz = yield withPlugin.using(TokenA, a).using(TokenB, B)(BazPlugin);
 });
-
 import { withPlugin } from "fusion-core";

--- a/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring
+++ b/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring
@@ -1,9 +1,6 @@
 import { gql } from 'fusion-plugin-apollo';
 import { gql as gqlOther } from 'gql';
 const path = './test';
-
 require("./file.graphql");
-
 gqlOther(path);
-
 require("./file.graphql");

--- a/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring-as
+++ b/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/expected-import-destructuring-as
@@ -1,5 +1,4 @@
 import { gql as frameworkgql } from 'fusion-apollo';
 import gql from 'gql';
 gql('./file.graphql');
-
 require("./file.graphql");

--- a/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring
+++ b/fusion-cli/build/babel-plugins/babel-plugin-gql/test/fixtures/input-import-destructuring
@@ -1,6 +1,5 @@
 import { gql } from 'fusion-plugin-apollo';
 import { gql as gqlOther } from 'gql';
-
 const path = './test';
 gql('./file.graphql');
 gqlOther(path);

--- a/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
+++ b/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-and-named
@@ -1,6 +1,4 @@
 import { createPlugin } from 'fusion-core';
 export const p = /*#__PURE__*/createPlugin({});
-
 var _default = /*#__PURE__*/createPlugin({});
-
 export default _default;

--- a/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
+++ b/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-export
@@ -1,5 +1,3 @@
 import { createPlugin } from 'fusion-core';
-
 var _default = /*#__PURE__*/createPlugin({});
-
 export default _default;

--- a/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
+++ b/fusion-cli/build/babel-plugins/babel-plugin-pure-create-plugin/test/fixtures/expected-default-multiline
@@ -1,10 +1,8 @@
 import { createPlugin } from 'fusion-core';
-
 var _default = /*#__PURE__*/createPlugin({
   deps: {
     a: 'b'
   },
   provides: () => {}
 });
-
 export default _default;

--- a/fusion-core/package.json
+++ b/fusion-core/package.json
@@ -23,7 +23,7 @@
     "@babel/traverse": "^7.15.0",
     "@babel/types": "^7.15.0",
     "@types/node": "*",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",

--- a/fusion-plugin-apollo/__tests__/apollo-client-local-state.js
+++ b/fusion-plugin-apollo/__tests__/apollo-client-local-state.js
@@ -11,7 +11,7 @@ import App, {createPlugin} from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
 import {FetchToken} from 'fusion-tokens';
 import {buildSchema} from 'graphql';
-import gql from 'graphql-tag';
+import {gql} from 'graphql-tag';
 import unfetch from 'unfetch';
 
 import {

--- a/fusion-plugin-apollo/__tests__/integration.node.js
+++ b/fusion-plugin-apollo/__tests__/integration.node.js
@@ -15,7 +15,7 @@ import {
   ApolloContextToken,
   ApolloDefaultOptionsConfigToken,
 } from '../src/index';
-import gql from 'graphql-tag';
+import {gql} from 'graphql-tag';
 import App from 'fusion-react';
 import {RenderToken} from 'fusion-core';
 import {ApolloClient} from 'apollo-client';

--- a/fusion-plugin-apollo/__tests__/server.node.js
+++ b/fusion-plugin-apollo/__tests__/server.node.js
@@ -18,7 +18,7 @@ import {
   GraphQLEndpointToken,
   ApolloContextToken,
 } from '../src/index';
-import gql from 'graphql-tag';
+import {gql} from 'graphql-tag';
 import {makeExecutableSchema} from 'graphql-tools';
 import {Query} from '@apollo/react-components';
 import App from 'fusion-react';

--- a/fusion-plugin-apollo/package.json
+++ b/fusion-plugin-apollo/package.json
@@ -24,7 +24,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-react": "workspace:*",

--- a/fusion-plugin-browser-performance-emitter/package.json
+++ b/fusion-plugin-browser-performance-emitter/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-universal-events": "workspace:*",

--- a/fusion-plugin-connected-react-router/package.json
+++ b/fusion-plugin-connected-react-router/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "connected-react-router": "^6.5.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-cli": "workspace:*",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-csrf-protection/package.json
+++ b/fusion-plugin-csrf-protection/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "body-parser": "^1.18.3",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "express": "^4.16.4",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
@@ -25,7 +25,7 @@
     "get-port": "^5.1.1",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "prettier": "^2.3.0",
+    "prettier": "^2.5.1",
     "sinon": "^7.1.1",
     "whatwg-fetch": "3.0.0"
   },

--- a/fusion-plugin-error-handling/package.json
+++ b/fusion-plugin-error-handling/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-test-utils": "workspace:*",

--- a/fusion-plugin-font-loader-react/package.json
+++ b/fusion-plugin-font-loader-react/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-react": "workspace:*",

--- a/fusion-plugin-http-handler/package.json
+++ b/fusion-plugin-http-handler/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "express": "^4.16.4",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-i18n-react/package.json
+++ b/fusion-plugin-i18n-react/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-react": "^7.14.5",
     "@testing-library/react": "^13.3.0",
     "babel-jest": "28.1.3",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-i18n": "workspace:*",

--- a/fusion-plugin-i18n/package.json
+++ b/fusion-plugin-i18n/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-universal-events": "workspace:*",

--- a/fusion-plugin-introspect/package.json
+++ b/fusion-plugin-introspect/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "^7.14.5",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "28.1.3",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-cli": "workspace:*",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-jwt/package.json
+++ b/fusion-plugin-jwt/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-tokens": "workspace:*",

--- a/fusion-plugin-node-performance-emitter/package.json
+++ b/fusion-plugin-node-performance-emitter/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-universal-events": "workspace:*",

--- a/fusion-plugin-react-helmet-async/package.json
+++ b/fusion-plugin-react-helmet-async/package.json
@@ -7,14 +7,14 @@
     "./dist-node-esm/index.js": "./dist-browser-esm/index.js"
   },
   "dependencies": {
-    "react-helmet-async": "^1.0.2"
+    "react-helmet-async": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-react": "workspace:*",

--- a/fusion-plugin-react-redux/__tests__/index.node.js
+++ b/fusion-plugin-react-redux/__tests__/index.node.js
@@ -183,12 +183,14 @@ test('enhancers - via app.register', async () => {
   await testEnhancer(myEnhancer);
 
   /* Enhancer plugin */
-  const myEnhancerPlugin: FusionPlugin<*, StoreEnhancer<*, *, *>> =
-    createPlugin({
-      provides() {
-        return myEnhancer;
-      },
-    });
+  const myEnhancerPlugin: FusionPlugin<
+    *,
+    StoreEnhancer<*, *, *>
+  > = createPlugin({
+    provides() {
+      return myEnhancer;
+    },
+  });
   await testEnhancer(myEnhancerPlugin);
 });
 

--- a/fusion-plugin-react-redux/package.json
+++ b/fusion-plugin-react-redux/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@testing-library/react": "^13.3.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "execa": "^1.0.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-react-router/package.json
+++ b/fusion-plugin-react-router/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-universal-events": "workspace:*",

--- a/fusion-plugin-redux-action-emitter-enhancer/package.json
+++ b/fusion-plugin-redux-action-emitter-enhancer/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-react-redux": "workspace:*",

--- a/fusion-plugin-rpc-redux-react/package.json
+++ b/fusion-plugin-rpc-redux-react/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "axios": "^0.21.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-cli": "workspace:*",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-rpc/package.json
+++ b/fusion-plugin-rpc/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "form-data": "^3.0.0",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-service-worker/package.json
+++ b/fusion-plugin-service-worker/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-cli": "workspace:*",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-styletron-react/package.json
+++ b/fusion-plugin-styletron-react/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-cli": "workspace:*",
     "fusion-core": "workspace:*",

--- a/fusion-plugin-styletron-react/test/basic/e2e.test.js
+++ b/fusion-plugin-styletron-react/test/basic/e2e.test.js
@@ -55,4 +55,4 @@ test('basic rendering and hydration works', async () => {
 
   server.kill();
   browser.close();
-}, 30000);
+}, 100000);

--- a/fusion-plugin-styletron-react/test/prefix-token/e2e.test.js
+++ b/fusion-plugin-styletron-react/test/prefix-token/e2e.test.js
@@ -45,4 +45,4 @@ test('token prefix', async () => {
 
   server.kill();
   browser.close();
-}, 30000);
+}, 100000);

--- a/fusion-plugin-universal-events/package.json
+++ b/fusion-plugin-universal-events/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-test-utils": "workspace:*",

--- a/fusion-plugin-universal-logger/package.json
+++ b/fusion-plugin-universal-logger/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-plugin-universal-events": "workspace:*",

--- a/fusion-plugin-web-app-manifest/package.json
+++ b/fusion-plugin-web-app-manifest/package.json
@@ -11,7 +11,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-tokens": "workspace:*",

--- a/fusion-react/package.json
+++ b/fusion-react/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "fusion-test-utils": "workspace:*",

--- a/fusion-rpc-redux/package.json
+++ b/fusion-rpc-redux/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "execa": "^1.0.0",
     "flow-bin": "0.131.0",
     "jest": "^28.1.3",

--- a/fusion-test-utils/package.json
+++ b/fusion-test-utils/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-react": "^7.14.5",
     "@types/jest": "25.2.3",
     "@types/node": "*",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "express": "^4.16.4",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",

--- a/fusion-tokens/package.json
+++ b/fusion-tokens/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
-    "create-universal-package": "^4.1.2",
+    "create-universal-package": "^4.3.0",
     "flow-bin": "0.131.0",
     "fusion-core": "workspace:*",
     "jest": "^28.1.3",

--- a/linter/.eslintrc.js
+++ b/linter/.eslintrc.js
@@ -1,4 +1,30 @@
 module.exports = {
   root: false,
   extends: ['eslint-config-fusion'],
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      parser: '@typescript-eslint/parser',
+      plugins: ['@typescript-eslint'],
+      rules: {
+        'flowtype/require-valid-file-annotation': 'off',
+        'flowtype/no-types-missing-file-annotation': 'off',
+        'cup/no-undef': 'off',
+        // does not work correctly with import type typescript feature todo: probably can be fixed with eslint tooling upgrade
+        'import/no-duplicates': 'off',
+
+        // disbled because missing dependency in fusion-core todo: review after fixing the types
+        'import/no-extraneous-dependencies': 'off',
+
+        // should be replaced with @typescript-eslint/no-unused-vars,
+        // but there is apparently a bug when importing type namespaces
+        'no-unused-vars': 'off',
+        'no-redeclare': 'off',
+        'no-dupe-class-members': 'off',
+        '@typescript-eslint/no-dupe-class-members': 'error',
+        'import/no-unresolved': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['**/*.d.ts'],
 };

--- a/linter/package.json
+++ b/linter/package.json
@@ -9,6 +9,8 @@
     "g:lint": "eslint $INIT_CWD --ignore-path $INIT_CWD/.gitignore --resolve-plugins-relative-to ."
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.27.0",
+    "@typescript-eslint/parser": "^5.27.0",
     "babel-eslint": "10.1.0",
     "eslint": "^7.27.0",
     "eslint-config-fusion": "workspace:*",
@@ -19,7 +21,8 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^4.1.0",
-    "prettier": "^2.3.0"
+    "prettier": "^2.5.1",
+    "typescript": "^4.8.4"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "packageManager": "yarn@3.2.4",
   "private": true,
   "workspaces": [
+    "types/create-universal-package-env",
     "fusion-tokens",
     "fusion-test-utils",
     "fusion-scaffolder",
@@ -45,5 +46,8 @@
     "react-dev-utils": {
       "unplugged": true
     }
+  },
+  "devDependencies": {
+    "typescript": "^4.8.4"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "jsx": "react",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}

--- a/types/create-universal-package-env/index.d.ts
+++ b/types/create-universal-package-env/index.d.ts
@@ -1,0 +1,3 @@
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/types/create-universal-package-env/package.json
+++ b/types/create-universal-package-env/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@types/create-universal-package-env",
+    "version": "0.0.0-monorepo",
+    "types": "./index.d.ts",
+    "private": true,
+    "scripts": {
+        "test": "echo OK",
+        "lint": "echo OK"
+    }
+}

--- a/types/create-universal-package-env/tsconfig.json
+++ b/types/create-universal-package-env/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [],
+  "include": ["./index.d.ts"],
+}


### PR DESCRIPTION
* gitignore for *.tsbuildinfo generated by incremental typescript build
* update react-helmet-async to support react 18 types
* upgrade create-universal-package (to the version with typescript support in it)
* upgrade prettier to support recent typescript syntax
* add typescript eslint support in linter package
* add base tsconfig, to be extended by tsconfigs in individual packages
* add @types/create-universal-package-env